### PR TITLE
fix: Get rid of trailing slash from the server URL

### DIFF
--- a/api/Govstack_scheduler_BB_APIs.json
+++ b/api/Govstack_scheduler_BB_APIs.json
@@ -1,3756 +1,3925 @@
 {
-  "openapi" : "3.0.1",
-  "info" : {
-    "title" : "Govstack Scheduler API",
-    "description" : "Interfaces to services rendered by Scheduler building block",
-    "termsOfService" : "TBD",
-    "contact" : {
-      "email" : "psramkumar2@gmail.com"
+  "openapi": "3.0.1",
+  "info": {
+    "title": "Govstack Scheduler API",
+    "description": "Interfaces to services rendered by Scheduler building block",
+    "termsOfService": "TBD",
+    "contact": {
+      "email": "psramkumar2@gmail.com"
     },
-    "license" : {
-      "name" : "Apache 2.0",
-      "url" : "http://www.apache.org/licenses/LICENSE-2.0.html"
+    "license": {
+      "name": "Apache 2.0",
+      "url": "http://www.apache.org/licenses/LICENSE-2.0.html"
     },
-    "version" : "1.0.0"
+    "version": "1.0.0"
   },
-  "externalDocs" : {
-    "description" : "Find out more about scheduler",
-    "url" : "https://www.govstack.global/"
+  "externalDocs": {
+    "description": "Find out more about scheduler",
+    "url": "https://www.govstack.global/"
   },
-  "servers" : [ {
-    "url" : "http://ss2.egovstack.net/r1/eGovStack/COM/11222456/SchedulerBB/creg/",
-    "description" : "Scheduler BB Security server"
-  } ],
-  "tags" : [ {
-    "name" : "event",
-    "description" : "event management API"
-  }, {
-    "name" : "entity",
-    "description" : "entity management API"
-  }, {
-    "name" : "alert_schedule",
-    "description" : "alert_schedule management  API"
-  }, {
-    "name" : "resource",
-    "description" : "resource  management API"
-  }, {
-    "name" : "subscribers",
-    "description" : "subscriber  management API"
-  }, {
-    "name" : "message",
-    "description" : "message management API"
-  }, {
-    "name" : "log",
-    "description" : "log management API"
-  }, {
-    "name" : "affiliation",
-    "description" : "affiliation management API"
-  }, {
-    "name" : "appointment",
-    "description" : "appointment management API"
-  } ],
-  "paths" : {
-    "/event/new" : {
-      "post" : {
-        "tags" : [ "event" ],
-        "summary" : "create a new event, in event_list with given event_details, returns new event id or failure error code",
-        "parameters" : [ {
-          "name" : "requestor_id",
-          "in" : "query",
-          "required" : true,
-          "style" : "form",
-          "explode" : true,
-          "schema" : {
-            "type" : "string",
-            "example" : "healthngoadmin1"
+  "servers": [
+    {
+      "url": "http://ss2.egovstack.net/r1/eGovStack/COM/11222456/SchedulerBB/creg",
+      "description": "Scheduler BB Security server"
+    }
+  ],
+  "tags": [
+    {
+      "name": "event",
+      "description": "event management API"
+    },
+    {
+      "name": "entity",
+      "description": "entity management API"
+    },
+    {
+      "name": "alert_schedule",
+      "description": "alert_schedule management  API"
+    },
+    {
+      "name": "resource",
+      "description": "resource  management API"
+    },
+    {
+      "name": "subscribers",
+      "description": "subscriber  management API"
+    },
+    {
+      "name": "message",
+      "description": "message management API"
+    },
+    {
+      "name": "log",
+      "description": "log management API"
+    },
+    {
+      "name": "affiliation",
+      "description": "affiliation management API"
+    },
+    {
+      "name": "appointment",
+      "description": "appointment management API"
+    }
+  ],
+  "paths": {
+    "/event/new": {
+      "post": {
+        "tags": ["event"],
+        "summary": "create a new event, in event_list with given event_details, returns new event id or failure error code",
+        "parameters": [
+          {
+            "name": "requestor_id",
+            "in": "query",
+            "required": true,
+            "style": "form",
+            "explode": true,
+            "schema": {
+              "type": "string",
+              "example": "healthngoadmin1"
+            }
+          },
+          {
+            "name": "request_token",
+            "in": "query",
+            "required": true,
+            "style": "form",
+            "explode": true,
+            "schema": {
+              "type": "string",
+              "example": "Organizer"
+            }
+          },
+          {
+            "name": "qry",
+            "in": "query",
+            "required": true,
+            "style": "form",
+            "explode": true,
+            "schema": {
+              "$ref": "#/components/schemas/event_new_qry"
+            }
           }
-        }, {
-          "name" : "request_token",
-          "in" : "query",
-          "required" : true,
-          "style" : "form",
-          "explode" : true,
-          "schema" : {
-            "type" : "string",
-            "example" : "Organizer"
-          }
-        }, {
-          "name" : "qry",
-          "in" : "query",
-          "required" : true,
-          "style" : "form",
-          "explode" : true,
-          "schema" : {
-            "$ref" : "#/components/schemas/event_new_qry"
-          }
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "success",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "type" : "string",
-                  "description" : "ID of created event",
-                  "example" : "event_id:12345"
+        ],
+        "responses": {
+          "200": {
+            "description": "success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string",
+                  "description": "ID of created event",
+                  "example": "event_id:12345"
                 }
               }
             }
           },
-          "400" : {
-            "description" : "Invalid request"
+          "400": {
+            "description": "Invalid request"
           },
-          "403" : {
-            "description" : "No permission"
+          "403": {
+            "description": "No permission"
           },
-          "404" : {
-            "description" : "one or more specified inputs not found"
+          "404": {
+            "description": "one or more specified inputs not found"
           },
-          "default" : {
-            "description" : "Unexpected error"
+          "default": {
+            "description": "Unexpected error"
           }
         }
       }
     },
-    "/event/modifications" : {
-      "put" : {
-        "tags" : [ "event" ],
-        "summary" : "changes values of specific details (as given by event_details) of given event (selected by event_filter)in event_list and returns success or error code",
-        "parameters" : [ {
-          "name" : "requestor_id",
-          "in" : "query",
-          "required" : true,
-          "style" : "form",
-          "explode" : true,
-          "schema" : {
-            "type" : "string",
-            "example" : "healthngoadmin1"
-          }
-        }, {
-          "name" : "request_token",
-          "in" : "query",
-          "required" : true,
-          "style" : "form",
-          "explode" : true,
-          "schema" : {
-            "type" : "string",
-            "example" : "Organizer"
-          }
-        }, {
-          "name" : "event_id",
-          "in" : "query",
-          "required" : true,
-          "style" : "form",
-          "explode" : true,
-          "schema" : {
-            "type" : "string",
-            "example" : "12345"
-          }
-        }, {
-          "name" : "qry",
-          "in" : "query",
-          "required" : true,
-          "style" : "form",
-          "explode" : true,
-          "schema" : {
-            "$ref" : "#/components/schemas/event_modify_qry"
-          }
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "success, event updated"
+    "/event/modifications": {
+      "put": {
+        "tags": ["event"],
+        "summary": "changes values of specific details (as given by event_details) of given event (selected by event_filter)in event_list and returns success or error code",
+        "parameters": [
+          {
+            "name": "requestor_id",
+            "in": "query",
+            "required": true,
+            "style": "form",
+            "explode": true,
+            "schema": {
+              "type": "string",
+              "example": "healthngoadmin1"
+            }
           },
-          "400" : {
-            "description" : "Invalid request"
+          {
+            "name": "request_token",
+            "in": "query",
+            "required": true,
+            "style": "form",
+            "explode": true,
+            "schema": {
+              "type": "string",
+              "example": "Organizer"
+            }
           },
-          "403" : {
-            "description" : "No permission"
+          {
+            "name": "event_id",
+            "in": "query",
+            "required": true,
+            "style": "form",
+            "explode": true,
+            "schema": {
+              "type": "string",
+              "example": "12345"
+            }
           },
-          "404" : {
-            "description" : "one or more specified inputs not found"
+          {
+            "name": "qry",
+            "in": "query",
+            "required": true,
+            "style": "form",
+            "explode": true,
+            "schema": {
+              "$ref": "#/components/schemas/event_modify_qry"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "success, event updated"
           },
-          "default" : {
-            "description" : "Unexpected error"
+          "400": {
+            "description": "Invalid request"
+          },
+          "403": {
+            "description": "No permission"
+          },
+          "404": {
+            "description": "one or more specified inputs not found"
+          },
+          "default": {
+            "description": "Unexpected error"
           }
         }
       }
     },
-    "/event" : {
-      "delete" : {
-        "tags" : [ "event" ],
-        "summary" : "delete a predefined event in event_list and returns success or error code",
-        "parameters" : [ {
-          "name" : "requestor_id",
-          "in" : "query",
-          "required" : true,
-          "style" : "form",
-          "explode" : true,
-          "schema" : {
-            "type" : "string",
-            "example" : "healthngoadmin1"
+    "/event": {
+      "delete": {
+        "tags": ["event"],
+        "summary": "delete a predefined event in event_list and returns success or error code",
+        "parameters": [
+          {
+            "name": "requestor_id",
+            "in": "query",
+            "required": true,
+            "style": "form",
+            "explode": true,
+            "schema": {
+              "type": "string",
+              "example": "healthngoadmin1"
+            }
+          },
+          {
+            "name": "request_token",
+            "in": "query",
+            "required": true,
+            "style": "form",
+            "explode": true,
+            "schema": {
+              "type": "string",
+              "example": "Organizer"
+            }
+          },
+          {
+            "name": "event_id",
+            "in": "query",
+            "required": true,
+            "style": "form",
+            "explode": true,
+            "schema": {
+              "type": "string",
+              "example": "12345"
+            }
           }
-        }, {
-          "name" : "request_token",
-          "in" : "query",
-          "required" : true,
-          "style" : "form",
-          "explode" : true,
-          "schema" : {
-            "type" : "string",
-            "example" : "Organizer"
-          }
-        }, {
-          "name" : "event_id",
-          "in" : "query",
-          "required" : true,
-          "style" : "form",
-          "explode" : true,
-          "schema" : {
-            "type" : "string",
-            "example" : "12345"
-          }
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "success, event cancelled"
+        ],
+        "responses": {
+          "200": {
+            "description": "success, event cancelled"
           },
-          "400" : {
-            "description" : "Invalid request"
+          "400": {
+            "description": "Invalid request"
           },
-          "403" : {
-            "description" : "No permission"
+          "403": {
+            "description": "No permission"
           },
-          "404" : {
-            "description" : "one or more specified inputs not found"
+          "404": {
+            "description": "one or more specified inputs not found"
           },
-          "default" : {
-            "description" : "Unexpected error"
+          "default": {
+            "description": "Unexpected error"
           }
         }
       }
     },
-    "/event/list_details" : {
-      "get" : {
-        "tags" : [ "event" ],
-        "summary" : "get list of events filetered by criteria in event_filter and return info specified by event_details_required with success or error code",
-        "parameters" : [ {
-          "name" : "requestor_id",
-          "in" : "query",
-          "required" : true,
-          "style" : "form",
-          "explode" : true,
-          "schema" : {
-            "type" : "string",
-            "example" : "healthngoadmin1"
+    "/event/list_details": {
+      "get": {
+        "tags": ["event"],
+        "summary": "get list of events filetered by criteria in event_filter and return info specified by event_details_required with success or error code",
+        "parameters": [
+          {
+            "name": "requestor_id",
+            "in": "query",
+            "required": true,
+            "style": "form",
+            "explode": true,
+            "schema": {
+              "type": "string",
+              "example": "healthngoadmin1"
+            }
+          },
+          {
+            "name": "request_token",
+            "in": "query",
+            "required": true,
+            "style": "form",
+            "explode": true,
+            "schema": {
+              "type": "string",
+              "example": "Organizer"
+            }
+          },
+          {
+            "name": "qry",
+            "in": "query",
+            "required": true,
+            "style": "form",
+            "explode": true,
+            "schema": {
+              "$ref": "#/components/schemas/event_get_details_qry"
+            }
           }
-        }, {
-          "name" : "request_token",
-          "in" : "query",
-          "required" : true,
-          "style" : "form",
-          "explode" : true,
-          "schema" : {
-            "type" : "string",
-            "example" : "Organizer"
-          }
-        }, {
-          "name" : "qry",
-          "in" : "query",
-          "required" : true,
-          "style" : "form",
-          "explode" : true,
-          "schema" : {
-            "$ref" : "#/components/schemas/event_get_details_qry"
-          }
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "success,event_list",
-            "content" : {
-              "json" : {
-                "schema" : {
-                  "type" : "array",
-                  "items" : {
-                    "$ref" : "#/components/schemas/event_list"
+        ],
+        "responses": {
+          "200": {
+            "description": "success,event_list",
+            "content": {
+              "json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/event_list"
                   }
                 }
               }
             }
           },
-          "400" : {
-            "description" : "Invalid request"
+          "400": {
+            "description": "Invalid request"
           },
-          "403" : {
-            "description" : "No permission"
+          "403": {
+            "description": "No permission"
           },
-          "404" : {
-            "description" : "one or more specified inputs not found"
+          "404": {
+            "description": "one or more specified inputs not found"
           },
-          "default" : {
-            "description" : "Unexpected error"
+          "default": {
+            "description": "Unexpected error"
           }
         }
       }
     },
-    "/appointment/new" : {
-      "post" : {
-        "tags" : [ "appointment" ],
-        "summary" : "create a new appointment, in appointment_list with given appointment_details, returns new appointment id or failure error code",
-        "parameters" : [ {
-          "name" : "requestor_id",
-          "in" : "query",
-          "required" : true,
-          "style" : "form",
-          "explode" : true,
-          "schema" : {
-            "type" : "string",
-            "example" : "healthngoadmin1"
+    "/appointment/new": {
+      "post": {
+        "tags": ["appointment"],
+        "summary": "create a new appointment, in appointment_list with given appointment_details, returns new appointment id or failure error code",
+        "parameters": [
+          {
+            "name": "requestor_id",
+            "in": "query",
+            "required": true,
+            "style": "form",
+            "explode": true,
+            "schema": {
+              "type": "string",
+              "example": "healthngoadmin1"
+            }
+          },
+          {
+            "name": "request_token",
+            "in": "query",
+            "required": true,
+            "style": "form",
+            "explode": true,
+            "schema": {
+              "type": "string",
+              "example": "Organizer"
+            }
+          },
+          {
+            "name": "qry",
+            "in": "query",
+            "required": true,
+            "style": "form",
+            "explode": true,
+            "schema": {
+              "$ref": "#/components/schemas/appointment_new_qry"
+            }
           }
-        }, {
-          "name" : "request_token",
-          "in" : "query",
-          "required" : true,
-          "style" : "form",
-          "explode" : true,
-          "schema" : {
-            "type" : "string",
-            "example" : "Organizer"
-          }
-        }, {
-          "name" : "qry",
-          "in" : "query",
-          "required" : true,
-          "style" : "form",
-          "explode" : true,
-          "schema" : {
-            "$ref" : "#/components/schemas/appointment_new_qry"
-          }
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "success",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "type" : "string",
-                  "description" : "ID of created appointment",
-                  "example" : "[Event_id:12345,appointment_id:1]"
+        ],
+        "responses": {
+          "200": {
+            "description": "success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string",
+                  "description": "ID of created appointment",
+                  "example": "[Event_id:12345,appointment_id:1]"
                 }
               }
             }
           },
-          "400" : {
-            "description" : "Invalid request"
+          "400": {
+            "description": "Invalid request"
           },
-          "403" : {
-            "description" : "No permission"
+          "403": {
+            "description": "No permission"
           },
-          "404" : {
-            "description" : "one or more specified inputs not found"
+          "404": {
+            "description": "one or more specified inputs not found"
           },
-          "default" : {
-            "description" : "Unexpected error"
+          "default": {
+            "description": "Unexpected error"
           }
         }
       }
     },
-    "/appointment/modifications" : {
-      "put" : {
-        "tags" : [ "appointment" ],
-        "summary" : "changes values of specific details (as given by appointment_details) of given appointment (selected by appointment_filter)in appointment_list and returns success or error code",
-        "parameters" : [ {
-          "name" : "requestor_id",
-          "in" : "query",
-          "required" : true,
-          "style" : "form",
-          "explode" : true,
-          "schema" : {
-            "type" : "string",
-            "example" : "healthngoadmin1"
-          }
-        }, {
-          "name" : "request_token",
-          "in" : "query",
-          "required" : true,
-          "style" : "form",
-          "explode" : true,
-          "schema" : {
-            "type" : "string",
-            "example" : "Organizer"
-          }
-        }, {
-          "name" : "appointment_id",
-          "in" : "query",
-          "required" : true,
-          "style" : "form",
-          "explode" : true,
-          "schema" : {
-            "type" : "string",
-            "example" : "1"
-          }
-        }, {
-          "name" : "qry",
-          "in" : "query",
-          "required" : true,
-          "style" : "form",
-          "explode" : true,
-          "schema" : {
-            "$ref" : "#/components/schemas/appointment_modify_qry"
-          }
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "success, appointment updated"
+    "/appointment/modifications": {
+      "put": {
+        "tags": ["appointment"],
+        "summary": "changes values of specific details (as given by appointment_details) of given appointment (selected by appointment_filter)in appointment_list and returns success or error code",
+        "parameters": [
+          {
+            "name": "requestor_id",
+            "in": "query",
+            "required": true,
+            "style": "form",
+            "explode": true,
+            "schema": {
+              "type": "string",
+              "example": "healthngoadmin1"
+            }
           },
-          "400" : {
-            "description" : "Invalid request"
+          {
+            "name": "request_token",
+            "in": "query",
+            "required": true,
+            "style": "form",
+            "explode": true,
+            "schema": {
+              "type": "string",
+              "example": "Organizer"
+            }
           },
-          "403" : {
-            "description" : "No permission"
+          {
+            "name": "appointment_id",
+            "in": "query",
+            "required": true,
+            "style": "form",
+            "explode": true,
+            "schema": {
+              "type": "string",
+              "example": "1"
+            }
           },
-          "404" : {
-            "description" : "one or more specified inputs not found"
+          {
+            "name": "qry",
+            "in": "query",
+            "required": true,
+            "style": "form",
+            "explode": true,
+            "schema": {
+              "$ref": "#/components/schemas/appointment_modify_qry"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "success, appointment updated"
           },
-          "default" : {
-            "description" : "Unexpected error"
+          "400": {
+            "description": "Invalid request"
+          },
+          "403": {
+            "description": "No permission"
+          },
+          "404": {
+            "description": "one or more specified inputs not found"
+          },
+          "default": {
+            "description": "Unexpected error"
           }
         }
       }
     },
-    "/appointment" : {
-      "delete" : {
-        "tags" : [ "appointment" ],
-        "summary" : "delete a predefined appointment in appointment_list and returns success or error code",
-        "parameters" : [ {
-          "name" : "requestor_id",
-          "in" : "query",
-          "required" : true,
-          "style" : "form",
-          "explode" : true,
-          "schema" : {
-            "type" : "string",
-            "example" : "healthngoadmin1"
+    "/appointment": {
+      "delete": {
+        "tags": ["appointment"],
+        "summary": "delete a predefined appointment in appointment_list and returns success or error code",
+        "parameters": [
+          {
+            "name": "requestor_id",
+            "in": "query",
+            "required": true,
+            "style": "form",
+            "explode": true,
+            "schema": {
+              "type": "string",
+              "example": "healthngoadmin1"
+            }
+          },
+          {
+            "name": "request_token",
+            "in": "query",
+            "required": true,
+            "style": "form",
+            "explode": true,
+            "schema": {
+              "type": "string",
+              "example": "Organizer"
+            }
+          },
+          {
+            "name": "appointment_id",
+            "in": "query",
+            "required": true,
+            "style": "form",
+            "explode": true,
+            "schema": {
+              "type": "string",
+              "example": "1"
+            }
           }
-        }, {
-          "name" : "request_token",
-          "in" : "query",
-          "required" : true,
-          "style" : "form",
-          "explode" : true,
-          "schema" : {
-            "type" : "string",
-            "example" : "Organizer"
-          }
-        }, {
-          "name" : "appointment_id",
-          "in" : "query",
-          "required" : true,
-          "style" : "form",
-          "explode" : true,
-          "schema" : {
-            "type" : "string",
-            "example" : "1"
-          }
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "success, appointment cancelled"
+        ],
+        "responses": {
+          "200": {
+            "description": "success, appointment cancelled"
           },
-          "400" : {
-            "description" : "Invalid request"
+          "400": {
+            "description": "Invalid request"
           },
-          "403" : {
-            "description" : "No permission"
+          "403": {
+            "description": "No permission"
           },
-          "404" : {
-            "description" : "one or more specified inputs not found"
+          "404": {
+            "description": "one or more specified inputs not found"
           },
-          "default" : {
-            "description" : "Unexpected error"
+          "default": {
+            "description": "Unexpected error"
           }
         }
       }
     },
-    "/appointment/list_details" : {
-      "get" : {
-        "tags" : [ "appointment" ],
-        "summary" : "get list of appointments filetered by criteria in appointment_filter and return info specified by appointment_details_required with success or error code",
-        "parameters" : [ {
-          "name" : "requestor_id",
-          "in" : "query",
-          "required" : true,
-          "style" : "form",
-          "explode" : true,
-          "schema" : {
-            "type" : "string",
-            "example" : "healthngoadmin1"
+    "/appointment/list_details": {
+      "get": {
+        "tags": ["appointment"],
+        "summary": "get list of appointments filetered by criteria in appointment_filter and return info specified by appointment_details_required with success or error code",
+        "parameters": [
+          {
+            "name": "requestor_id",
+            "in": "query",
+            "required": true,
+            "style": "form",
+            "explode": true,
+            "schema": {
+              "type": "string",
+              "example": "healthngoadmin1"
+            }
+          },
+          {
+            "name": "request_token",
+            "in": "query",
+            "required": true,
+            "style": "form",
+            "explode": true,
+            "schema": {
+              "type": "string",
+              "example": "Organizer"
+            }
+          },
+          {
+            "name": "qry",
+            "in": "query",
+            "required": true,
+            "style": "form",
+            "explode": true,
+            "schema": {
+              "$ref": "#/components/schemas/appointment_get_details_qry"
+            }
           }
-        }, {
-          "name" : "request_token",
-          "in" : "query",
-          "required" : true,
-          "style" : "form",
-          "explode" : true,
-          "schema" : {
-            "type" : "string",
-            "example" : "Organizer"
-          }
-        }, {
-          "name" : "qry",
-          "in" : "query",
-          "required" : true,
-          "style" : "form",
-          "explode" : true,
-          "schema" : {
-            "$ref" : "#/components/schemas/appointment_get_details_qry"
-          }
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "success,appointment_list",
-            "content" : {
-              "json" : {
-                "schema" : {
-                  "type" : "array",
-                  "items" : {
-                    "$ref" : "#/components/schemas/appointment_list"
+        ],
+        "responses": {
+          "200": {
+            "description": "success,appointment_list",
+            "content": {
+              "json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/appointment_list"
                   }
                 }
               }
             }
           },
-          "400" : {
-            "description" : "Invalid request"
+          "400": {
+            "description": "Invalid request"
           },
-          "403" : {
-            "description" : "No permission"
+          "403": {
+            "description": "No permission"
           },
-          "404" : {
-            "description" : "one or more specified inputs not found"
+          "404": {
+            "description": "one or more specified inputs not found"
           },
-          "default" : {
-            "description" : "Unexpected error"
+          "default": {
+            "description": "Unexpected error"
           }
         }
       }
     },
-    "/entity/new" : {
-      "post" : {
-        "tags" : [ "entity" ],
-        "summary" : "create a new entity, in entity_list with given entity_details, returns new entity id or entity error code",
-        "parameters" : [ {
-          "name" : "requestor_id",
-          "in" : "query",
-          "required" : true,
-          "style" : "form",
-          "explode" : true,
-          "schema" : {
-            "type" : "string",
-            "example" : "healthngoadmin1"
+    "/entity/new": {
+      "post": {
+        "tags": ["entity"],
+        "summary": "create a new entity, in entity_list with given entity_details, returns new entity id or entity error code",
+        "parameters": [
+          {
+            "name": "requestor_id",
+            "in": "query",
+            "required": true,
+            "style": "form",
+            "explode": true,
+            "schema": {
+              "type": "string",
+              "example": "healthngoadmin1"
+            }
+          },
+          {
+            "name": "request_token",
+            "in": "query",
+            "required": true,
+            "style": "form",
+            "explode": true,
+            "schema": {
+              "type": "string",
+              "example": "Organizer"
+            }
+          },
+          {
+            "name": "qry",
+            "in": "query",
+            "required": true,
+            "style": "form",
+            "explode": true,
+            "schema": {
+              "$ref": "#/components/schemas/entity_new_qry"
+            }
           }
-        }, {
-          "name" : "request_token",
-          "in" : "query",
-          "required" : true,
-          "style" : "form",
-          "explode" : true,
-          "schema" : {
-            "type" : "string",
-            "example" : "Organizer"
-          }
-        }, {
-          "name" : "qry",
-          "in" : "query",
-          "required" : true,
-          "style" : "form",
-          "explode" : true,
-          "schema" : {
-            "$ref" : "#/components/schemas/entity_new_qry"
-          }
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "success",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "type" : "string",
-                  "description" : "ID of created entity",
-                  "example" : "entity_name:xyz hospital,entity_id:67890"
+        ],
+        "responses": {
+          "200": {
+            "description": "success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string",
+                  "description": "ID of created entity",
+                  "example": "entity_name:xyz hospital,entity_id:67890"
                 }
               }
             }
           },
-          "400" : {
-            "description" : "Invalid request"
+          "400": {
+            "description": "Invalid request"
           },
-          "403" : {
-            "description" : "No permission"
+          "403": {
+            "description": "No permission"
           },
-          "404" : {
-            "description" : "one or more specified inputs not found"
+          "404": {
+            "description": "one or more specified inputs not found"
           },
-          "default" : {
-            "description" : "Unexpected error"
+          "default": {
+            "description": "Unexpected error"
           }
         }
       }
     },
-    "/entity/modifications" : {
-      "put" : {
-        "tags" : [ "entity" ],
-        "summary" : "changes values of specific details (as given by entity_details) of given entity (selected by entity_filter)in entity_list and returns success or error code",
-        "parameters" : [ {
-          "name" : "requestor_id",
-          "in" : "query",
-          "required" : true,
-          "style" : "form",
-          "explode" : true,
-          "schema" : {
-            "type" : "string",
-            "example" : "healthngoadmin1"
-          }
-        }, {
-          "name" : "request_token",
-          "in" : "query",
-          "required" : true,
-          "style" : "form",
-          "explode" : true,
-          "schema" : {
-            "type" : "string",
-            "example" : "Organizer"
-          }
-        }, {
-          "name" : "entity_id",
-          "in" : "query",
-          "required" : true,
-          "style" : "form",
-          "explode" : true,
-          "schema" : {
-            "type" : "string",
-            "example" : "67890"
-          }
-        }, {
-          "name" : "qry",
-          "in" : "query",
-          "required" : true,
-          "style" : "form",
-          "explode" : true,
-          "schema" : {
-            "$ref" : "#/components/schemas/entity_modify_qry"
-          }
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "success, entity updated"
+    "/entity/modifications": {
+      "put": {
+        "tags": ["entity"],
+        "summary": "changes values of specific details (as given by entity_details) of given entity (selected by entity_filter)in entity_list and returns success or error code",
+        "parameters": [
+          {
+            "name": "requestor_id",
+            "in": "query",
+            "required": true,
+            "style": "form",
+            "explode": true,
+            "schema": {
+              "type": "string",
+              "example": "healthngoadmin1"
+            }
           },
-          "400" : {
-            "description" : "Invalid request"
+          {
+            "name": "request_token",
+            "in": "query",
+            "required": true,
+            "style": "form",
+            "explode": true,
+            "schema": {
+              "type": "string",
+              "example": "Organizer"
+            }
           },
-          "403" : {
-            "description" : "No permission"
+          {
+            "name": "entity_id",
+            "in": "query",
+            "required": true,
+            "style": "form",
+            "explode": true,
+            "schema": {
+              "type": "string",
+              "example": "67890"
+            }
           },
-          "404" : {
-            "description" : "one or more specified inputs not found"
+          {
+            "name": "qry",
+            "in": "query",
+            "required": true,
+            "style": "form",
+            "explode": true,
+            "schema": {
+              "$ref": "#/components/schemas/entity_modify_qry"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "success, entity updated"
           },
-          "default" : {
-            "description" : "Unexpected error"
+          "400": {
+            "description": "Invalid request"
+          },
+          "403": {
+            "description": "No permission"
+          },
+          "404": {
+            "description": "one or more specified inputs not found"
+          },
+          "default": {
+            "description": "Unexpected error"
           }
         }
       }
     },
-    "/entity" : {
-      "delete" : {
-        "tags" : [ "entity" ],
-        "summary" : "delete a predefined entity in entity_list and returns success or error code",
-        "parameters" : [ {
-          "name" : "requestor_id",
-          "in" : "query",
-          "required" : true,
-          "style" : "form",
-          "explode" : true,
-          "schema" : {
-            "type" : "string",
-            "example" : "healthngoadmin1"
+    "/entity": {
+      "delete": {
+        "tags": ["entity"],
+        "summary": "delete a predefined entity in entity_list and returns success or error code",
+        "parameters": [
+          {
+            "name": "requestor_id",
+            "in": "query",
+            "required": true,
+            "style": "form",
+            "explode": true,
+            "schema": {
+              "type": "string",
+              "example": "healthngoadmin1"
+            }
+          },
+          {
+            "name": "request_token",
+            "in": "query",
+            "required": true,
+            "style": "form",
+            "explode": true,
+            "schema": {
+              "type": "string",
+              "example": "Organizer"
+            }
+          },
+          {
+            "name": "entity_id",
+            "in": "query",
+            "required": true,
+            "style": "form",
+            "explode": true,
+            "schema": {
+              "type": "string",
+              "example": "67890"
+            }
           }
-        }, {
-          "name" : "request_token",
-          "in" : "query",
-          "required" : true,
-          "style" : "form",
-          "explode" : true,
-          "schema" : {
-            "type" : "string",
-            "example" : "Organizer"
-          }
-        }, {
-          "name" : "entity_id",
-          "in" : "query",
-          "required" : true,
-          "style" : "form",
-          "explode" : true,
-          "schema" : {
-            "type" : "string",
-            "example" : "67890"
-          }
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "success, entity cancelled"
+        ],
+        "responses": {
+          "200": {
+            "description": "success, entity cancelled"
           },
-          "400" : {
-            "description" : "Invalid request"
+          "400": {
+            "description": "Invalid request"
           },
-          "403" : {
-            "description" : "No permission"
+          "403": {
+            "description": "No permission"
           },
-          "404" : {
-            "description" : "one or more specified inputs not found"
+          "404": {
+            "description": "one or more specified inputs not found"
           },
-          "default" : {
-            "description" : "Unexpected error"
+          "default": {
+            "description": "Unexpected error"
           }
         }
       }
     },
-    "/entity/list_details" : {
-      "get" : {
-        "tags" : [ "entity" ],
-        "summary" : "get list of entities filetered by criteria in entity_filter and return info specified by entity_details_required with success or error code",
-        "parameters" : [ {
-          "name" : "requestor_id",
-          "in" : "query",
-          "required" : true,
-          "style" : "form",
-          "explode" : true,
-          "schema" : {
-            "type" : "string",
-            "example" : "healthngoadmin1"
+    "/entity/list_details": {
+      "get": {
+        "tags": ["entity"],
+        "summary": "get list of entities filetered by criteria in entity_filter and return info specified by entity_details_required with success or error code",
+        "parameters": [
+          {
+            "name": "requestor_id",
+            "in": "query",
+            "required": true,
+            "style": "form",
+            "explode": true,
+            "schema": {
+              "type": "string",
+              "example": "healthngoadmin1"
+            }
+          },
+          {
+            "name": "request_token",
+            "in": "query",
+            "required": true,
+            "style": "form",
+            "explode": true,
+            "schema": {
+              "type": "string",
+              "example": "Organizer"
+            }
+          },
+          {
+            "name": "qry",
+            "in": "query",
+            "required": true,
+            "style": "form",
+            "explode": true,
+            "schema": {
+              "$ref": "#/components/schemas/entity_get_details_qry"
+            }
           }
-        }, {
-          "name" : "request_token",
-          "in" : "query",
-          "required" : true,
-          "style" : "form",
-          "explode" : true,
-          "schema" : {
-            "type" : "string",
-            "example" : "Organizer"
-          }
-        }, {
-          "name" : "qry",
-          "in" : "query",
-          "required" : true,
-          "style" : "form",
-          "explode" : true,
-          "schema" : {
-            "$ref" : "#/components/schemas/entity_get_details_qry"
-          }
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "success,entity list",
-            "content" : {
-              "json" : {
-                "schema" : {
-                  "type" : "array",
-                  "items" : {
-                    "$ref" : "#/components/schemas/entity_list"
+        ],
+        "responses": {
+          "200": {
+            "description": "success,entity list",
+            "content": {
+              "json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/entity_list"
                   }
                 }
               }
             }
           },
-          "400" : {
-            "description" : "Invalid request"
+          "400": {
+            "description": "Invalid request"
           },
-          "403" : {
-            "description" : "No permission"
+          "403": {
+            "description": "No permission"
           },
-          "404" : {
-            "description" : "one or more specified inputs not found"
+          "404": {
+            "description": "one or more specified inputs not found"
           },
-          "default" : {
-            "description" : "Unexpected error"
+          "default": {
+            "description": "Unexpected error"
           }
         }
       }
     },
-    "/resource/new" : {
-      "post" : {
-        "tags" : [ "resource" ],
-        "summary" : "create a new resource, in resource_list with given resource_details, returns new resource id or  error code",
-        "parameters" : [ {
-          "name" : "requestor_id",
-          "in" : "query",
-          "required" : true,
-          "style" : "form",
-          "explode" : true,
-          "schema" : {
-            "type" : "string",
-            "example" : "healthngoadmin1"
+    "/resource/new": {
+      "post": {
+        "tags": ["resource"],
+        "summary": "create a new resource, in resource_list with given resource_details, returns new resource id or  error code",
+        "parameters": [
+          {
+            "name": "requestor_id",
+            "in": "query",
+            "required": true,
+            "style": "form",
+            "explode": true,
+            "schema": {
+              "type": "string",
+              "example": "healthngoadmin1"
+            }
+          },
+          {
+            "name": "request_token",
+            "in": "query",
+            "required": true,
+            "style": "form",
+            "explode": true,
+            "schema": {
+              "type": "string",
+              "example": "Organizer"
+            }
+          },
+          {
+            "name": "qry",
+            "in": "query",
+            "required": true,
+            "style": "form",
+            "explode": true,
+            "schema": {
+              "$ref": "#/components/schemas/resource_new_qry"
+            }
           }
-        }, {
-          "name" : "request_token",
-          "in" : "query",
-          "required" : true,
-          "style" : "form",
-          "explode" : true,
-          "schema" : {
-            "type" : "string",
-            "example" : "Organizer"
-          }
-        }, {
-          "name" : "qry",
-          "in" : "query",
-          "required" : true,
-          "style" : "form",
-          "explode" : true,
-          "schema" : {
-            "$ref" : "#/components/schemas/resource_new_qry"
-          }
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "success",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "type" : "string",
-                  "description" : "ID of created resource",
-                  "example" : "resource_name:xyz hospital,resource_id:54321"
+        ],
+        "responses": {
+          "200": {
+            "description": "success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string",
+                  "description": "ID of created resource",
+                  "example": "resource_name:xyz hospital,resource_id:54321"
                 }
               }
             }
           },
-          "400" : {
-            "description" : "Invalid request"
+          "400": {
+            "description": "Invalid request"
           },
-          "403" : {
-            "description" : "No permission"
+          "403": {
+            "description": "No permission"
           },
-          "404" : {
-            "description" : "one or more specified inputs not found"
+          "404": {
+            "description": "one or more specified inputs not found"
           },
-          "default" : {
-            "description" : "Unexpected error"
+          "default": {
+            "description": "Unexpected error"
           }
         }
       }
     },
-    "/resource/modifications" : {
-      "put" : {
-        "tags" : [ "resource" ],
-        "summary" : "changes values of specific details (as given by resource_details) of given resource (selected by resource_filter)in resource_list and returns success or error code",
-        "parameters" : [ {
-          "name" : "requestor_id",
-          "in" : "query",
-          "required" : true,
-          "style" : "form",
-          "explode" : true,
-          "schema" : {
-            "type" : "string",
-            "example" : "healthngoadmin1"
-          }
-        }, {
-          "name" : "request_token",
-          "in" : "query",
-          "required" : true,
-          "style" : "form",
-          "explode" : true,
-          "schema" : {
-            "type" : "string",
-            "example" : "Organizer"
-          }
-        }, {
-          "name" : "resource_id",
-          "in" : "query",
-          "required" : true,
-          "style" : "form",
-          "explode" : true,
-          "schema" : {
-            "type" : "string",
-            "example" : "54321"
-          }
-        }, {
-          "name" : "qry",
-          "in" : "query",
-          "required" : true,
-          "style" : "form",
-          "explode" : true,
-          "schema" : {
-            "$ref" : "#/components/schemas/resource_modify_qry"
-          }
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "success, resource updated"
+    "/resource/modifications": {
+      "put": {
+        "tags": ["resource"],
+        "summary": "changes values of specific details (as given by resource_details) of given resource (selected by resource_filter)in resource_list and returns success or error code",
+        "parameters": [
+          {
+            "name": "requestor_id",
+            "in": "query",
+            "required": true,
+            "style": "form",
+            "explode": true,
+            "schema": {
+              "type": "string",
+              "example": "healthngoadmin1"
+            }
           },
-          "400" : {
-            "description" : "Invalid request"
+          {
+            "name": "request_token",
+            "in": "query",
+            "required": true,
+            "style": "form",
+            "explode": true,
+            "schema": {
+              "type": "string",
+              "example": "Organizer"
+            }
           },
-          "403" : {
-            "description" : "No permission"
+          {
+            "name": "resource_id",
+            "in": "query",
+            "required": true,
+            "style": "form",
+            "explode": true,
+            "schema": {
+              "type": "string",
+              "example": "54321"
+            }
           },
-          "404" : {
-            "description" : "one or more specified inputs not found"
+          {
+            "name": "qry",
+            "in": "query",
+            "required": true,
+            "style": "form",
+            "explode": true,
+            "schema": {
+              "$ref": "#/components/schemas/resource_modify_qry"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "success, resource updated"
           },
-          "default" : {
-            "description" : "Unexpected error"
+          "400": {
+            "description": "Invalid request"
+          },
+          "403": {
+            "description": "No permission"
+          },
+          "404": {
+            "description": "one or more specified inputs not found"
+          },
+          "default": {
+            "description": "Unexpected error"
           }
         }
       }
     },
-    "/resource" : {
-      "delete" : {
-        "tags" : [ "resource" ],
-        "summary" : "delete a predefined resource in resource_list and returns success or error code",
-        "parameters" : [ {
-          "name" : "requestor_id",
-          "in" : "query",
-          "required" : true,
-          "style" : "form",
-          "explode" : true,
-          "schema" : {
-            "type" : "string",
-            "example" : "healthngoadmin1"
+    "/resource": {
+      "delete": {
+        "tags": ["resource"],
+        "summary": "delete a predefined resource in resource_list and returns success or error code",
+        "parameters": [
+          {
+            "name": "requestor_id",
+            "in": "query",
+            "required": true,
+            "style": "form",
+            "explode": true,
+            "schema": {
+              "type": "string",
+              "example": "healthngoadmin1"
+            }
+          },
+          {
+            "name": "request_token",
+            "in": "query",
+            "required": true,
+            "style": "form",
+            "explode": true,
+            "schema": {
+              "type": "string",
+              "example": "Organizer"
+            }
+          },
+          {
+            "name": "resource_id",
+            "in": "query",
+            "required": true,
+            "style": "form",
+            "explode": true,
+            "schema": {
+              "type": "string",
+              "example": "54321"
+            }
           }
-        }, {
-          "name" : "request_token",
-          "in" : "query",
-          "required" : true,
-          "style" : "form",
-          "explode" : true,
-          "schema" : {
-            "type" : "string",
-            "example" : "Organizer"
-          }
-        }, {
-          "name" : "resource_id",
-          "in" : "query",
-          "required" : true,
-          "style" : "form",
-          "explode" : true,
-          "schema" : {
-            "type" : "string",
-            "example" : "54321"
-          }
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "success, resource cancelled"
+        ],
+        "responses": {
+          "200": {
+            "description": "success, resource cancelled"
           },
-          "400" : {
-            "description" : "Invalid request"
+          "400": {
+            "description": "Invalid request"
           },
-          "403" : {
-            "description" : "No permission"
+          "403": {
+            "description": "No permission"
           },
-          "404" : {
-            "description" : "one or more specified inputs not found"
+          "404": {
+            "description": "one or more specified inputs not found"
           },
-          "default" : {
-            "description" : "Unexpected error"
+          "default": {
+            "description": "Unexpected error"
           }
         }
       }
     },
-    "/resource/list_details" : {
-      "get" : {
-        "tags" : [ "resource" ],
-        "summary" : "get list of entities filetered by criteria in resource_filter and return info specified by resource_details_required with success or error code",
-        "parameters" : [ {
-          "name" : "requestor_id",
-          "in" : "query",
-          "required" : true,
-          "style" : "form",
-          "explode" : true,
-          "schema" : {
-            "type" : "string",
-            "example" : "healthngoadmin1"
+    "/resource/list_details": {
+      "get": {
+        "tags": ["resource"],
+        "summary": "get list of entities filetered by criteria in resource_filter and return info specified by resource_details_required with success or error code",
+        "parameters": [
+          {
+            "name": "requestor_id",
+            "in": "query",
+            "required": true,
+            "style": "form",
+            "explode": true,
+            "schema": {
+              "type": "string",
+              "example": "healthngoadmin1"
+            }
+          },
+          {
+            "name": "request_token",
+            "in": "query",
+            "required": true,
+            "style": "form",
+            "explode": true,
+            "schema": {
+              "type": "string",
+              "example": "Organizer"
+            }
+          },
+          {
+            "name": "qry",
+            "in": "query",
+            "required": true,
+            "style": "form",
+            "explode": true,
+            "schema": {
+              "$ref": "#/components/schemas/resource_get_details_qry"
+            }
           }
-        }, {
-          "name" : "request_token",
-          "in" : "query",
-          "required" : true,
-          "style" : "form",
-          "explode" : true,
-          "schema" : {
-            "type" : "string",
-            "example" : "Organizer"
-          }
-        }, {
-          "name" : "qry",
-          "in" : "query",
-          "required" : true,
-          "style" : "form",
-          "explode" : true,
-          "schema" : {
-            "$ref" : "#/components/schemas/resource_get_details_qry"
-          }
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "success,resource list",
-            "content" : {
-              "json" : {
-                "schema" : {
-                  "type" : "array",
-                  "items" : {
-                    "$ref" : "#/components/schemas/resource_list"
+        ],
+        "responses": {
+          "200": {
+            "description": "success,resource list",
+            "content": {
+              "json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/resource_list"
                   }
                 }
               }
             }
           },
-          "400" : {
-            "description" : "Invalid request"
+          "400": {
+            "description": "Invalid request"
           },
-          "403" : {
-            "description" : "No permission"
+          "403": {
+            "description": "No permission"
           },
-          "404" : {
-            "description" : "one or more specified inputs not found"
+          "404": {
+            "description": "one or more specified inputs not found"
           },
-          "default" : {
-            "description" : "Unexpected error"
+          "default": {
+            "description": "Unexpected error"
           }
         }
       }
     },
-    "/resource/availability" : {
-      "get" : {
-        "tags" : [ "resource" ],
-        "summary" : "get details of resources matching criteria given by free_resource_filter, that are free(unallocated) in a given date range and entity and returns success or error code",
-        "parameters" : [ {
-          "name" : "requestor_id",
-          "in" : "query",
-          "required" : true,
-          "style" : "form",
-          "explode" : true,
-          "schema" : {
-            "type" : "string",
-            "example" : "healthngoadmin1"
+    "/resource/availability": {
+      "get": {
+        "tags": ["resource"],
+        "summary": "get details of resources matching criteria given by free_resource_filter, that are free(unallocated) in a given date range and entity and returns success or error code",
+        "parameters": [
+          {
+            "name": "requestor_id",
+            "in": "query",
+            "required": true,
+            "style": "form",
+            "explode": true,
+            "schema": {
+              "type": "string",
+              "example": "healthngoadmin1"
+            }
+          },
+          {
+            "name": "request_token",
+            "in": "query",
+            "required": true,
+            "style": "form",
+            "explode": true,
+            "schema": {
+              "type": "string",
+              "example": "Organizer"
+            }
+          },
+          {
+            "name": "qry",
+            "in": "query",
+            "required": true,
+            "style": "form",
+            "explode": true,
+            "schema": {
+              "$ref": "#/components/schemas/resource_get_availability_qry"
+            }
           }
-        }, {
-          "name" : "request_token",
-          "in" : "query",
-          "required" : true,
-          "style" : "form",
-          "explode" : true,
-          "schema" : {
-            "type" : "string",
-            "example" : "Organizer"
-          }
-        }, {
-          "name" : "qry",
-          "in" : "query",
-          "required" : true,
-          "style" : "form",
-          "explode" : true,
-          "schema" : {
-            "$ref" : "#/components/schemas/resource_get_availability_qry"
-          }
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "success,resource  list",
-            "content" : {
-              "json" : {
-                "schema" : {
-                  "type" : "array",
-                  "items" : {
-                    "$ref" : "#/components/schemas/free_resource_list"
+        ],
+        "responses": {
+          "200": {
+            "description": "success,resource  list",
+            "content": {
+              "json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/free_resource_list"
                   }
                 }
               }
             }
           },
-          "400" : {
-            "description" : "Invalid request"
+          "400": {
+            "description": "Invalid request"
           },
-          "403" : {
-            "description" : "No permission"
+          "403": {
+            "description": "No permission"
           },
-          "404" : {
-            "description" : "one or more specified inputs not found"
+          "404": {
+            "description": "one or more specified inputs not found"
           },
-          "default" : {
-            "description" : "Unexpected error"
+          "default": {
+            "description": "Unexpected error"
           }
         }
       }
     },
-    "/subscriber/new" : {
-      "post" : {
-        "tags" : [ "subscriber" ],
-        "summary" : "create a new subscriber, in subscriber_list with given subscriber_details, returns new subscriber id or  error code",
-        "parameters" : [ {
-          "name" : "requestor_id",
-          "in" : "query",
-          "required" : true,
-          "style" : "form",
-          "explode" : true,
-          "schema" : {
-            "type" : "string",
-            "example" : "healthngoadmin1"
+    "/subscriber/new": {
+      "post": {
+        "tags": ["subscriber"],
+        "summary": "create a new subscriber, in subscriber_list with given subscriber_details, returns new subscriber id or  error code",
+        "parameters": [
+          {
+            "name": "requestor_id",
+            "in": "query",
+            "required": true,
+            "style": "form",
+            "explode": true,
+            "schema": {
+              "type": "string",
+              "example": "healthngoadmin1"
+            }
+          },
+          {
+            "name": "request_token",
+            "in": "query",
+            "required": true,
+            "style": "form",
+            "explode": true,
+            "schema": {
+              "type": "string",
+              "example": "Organizer"
+            }
+          },
+          {
+            "name": "qry",
+            "in": "query",
+            "required": true,
+            "style": "form",
+            "explode": true,
+            "schema": {
+              "$ref": "#/components/schemas/subscriber_new_qry"
+            }
           }
-        }, {
-          "name" : "request_token",
-          "in" : "query",
-          "required" : true,
-          "style" : "form",
-          "explode" : true,
-          "schema" : {
-            "type" : "string",
-            "example" : "Organizer"
-          }
-        }, {
-          "name" : "qry",
-          "in" : "query",
-          "required" : true,
-          "style" : "form",
-          "explode" : true,
-          "schema" : {
-            "$ref" : "#/components/schemas/subscriber_new_qry"
-          }
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "success",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "type" : "string",
-                  "description" : "ID of created subscriber",
-                  "example" : "subscriber_name:xyz hospital,subscriber_id:12345"
+        ],
+        "responses": {
+          "200": {
+            "description": "success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string",
+                  "description": "ID of created subscriber",
+                  "example": "subscriber_name:xyz hospital,subscriber_id:12345"
                 }
               }
             }
           },
-          "400" : {
-            "description" : "Invalid request"
+          "400": {
+            "description": "Invalid request"
           },
-          "403" : {
-            "description" : "No permission"
+          "403": {
+            "description": "No permission"
           },
-          "404" : {
-            "description" : "one or more specified inputs not found"
+          "404": {
+            "description": "one or more specified inputs not found"
           },
-          "default" : {
-            "description" : "Unexpected error"
+          "default": {
+            "description": "Unexpected error"
           }
         }
       }
     },
-    "/subscriber/modifications" : {
-      "put" : {
-        "tags" : [ "subscriber" ],
-        "summary" : "changes values of specific details (as given by subscriber_details) of given subscriber (selected by subscriber_filter)in subscriber_list and returns success or error code",
-        "parameters" : [ {
-          "name" : "requestor_id",
-          "in" : "query",
-          "required" : true,
-          "style" : "form",
-          "explode" : true,
-          "schema" : {
-            "type" : "string",
-            "example" : "healthngoadmin1"
-          }
-        }, {
-          "name" : "request_token",
-          "in" : "query",
-          "required" : true,
-          "style" : "form",
-          "explode" : true,
-          "schema" : {
-            "type" : "string",
-            "example" : "Organizer"
-          }
-        }, {
-          "name" : "subscriber_id",
-          "in" : "query",
-          "required" : true,
-          "style" : "form",
-          "explode" : true,
-          "schema" : {
-            "type" : "string",
-            "example" : "12345"
-          }
-        }, {
-          "name" : "qry",
-          "in" : "query",
-          "required" : true,
-          "style" : "form",
-          "explode" : true,
-          "schema" : {
-            "$ref" : "#/components/schemas/subscriber_modify_qry"
-          }
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "success, subscriber updated"
+    "/subscriber/modifications": {
+      "put": {
+        "tags": ["subscriber"],
+        "summary": "changes values of specific details (as given by subscriber_details) of given subscriber (selected by subscriber_filter)in subscriber_list and returns success or error code",
+        "parameters": [
+          {
+            "name": "requestor_id",
+            "in": "query",
+            "required": true,
+            "style": "form",
+            "explode": true,
+            "schema": {
+              "type": "string",
+              "example": "healthngoadmin1"
+            }
           },
-          "400" : {
-            "description" : "Invalid request"
+          {
+            "name": "request_token",
+            "in": "query",
+            "required": true,
+            "style": "form",
+            "explode": true,
+            "schema": {
+              "type": "string",
+              "example": "Organizer"
+            }
           },
-          "403" : {
-            "description" : "No permission"
+          {
+            "name": "subscriber_id",
+            "in": "query",
+            "required": true,
+            "style": "form",
+            "explode": true,
+            "schema": {
+              "type": "string",
+              "example": "12345"
+            }
           },
-          "404" : {
-            "description" : "one or more specified inputs not found"
+          {
+            "name": "qry",
+            "in": "query",
+            "required": true,
+            "style": "form",
+            "explode": true,
+            "schema": {
+              "$ref": "#/components/schemas/subscriber_modify_qry"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "success, subscriber updated"
           },
-          "default" : {
-            "description" : "Unexpected error"
+          "400": {
+            "description": "Invalid request"
+          },
+          "403": {
+            "description": "No permission"
+          },
+          "404": {
+            "description": "one or more specified inputs not found"
+          },
+          "default": {
+            "description": "Unexpected error"
           }
         }
       }
     },
-    "/subscriber" : {
-      "delete" : {
-        "tags" : [ "subscriber" ],
-        "summary" : "delete a predefined subscriber in subscriber_list and returns success or error code",
-        "parameters" : [ {
-          "name" : "requestor_id",
-          "in" : "query",
-          "required" : true,
-          "style" : "form",
-          "explode" : true,
-          "schema" : {
-            "type" : "string",
-            "example" : "healthngoadmin1"
+    "/subscriber": {
+      "delete": {
+        "tags": ["subscriber"],
+        "summary": "delete a predefined subscriber in subscriber_list and returns success or error code",
+        "parameters": [
+          {
+            "name": "requestor_id",
+            "in": "query",
+            "required": true,
+            "style": "form",
+            "explode": true,
+            "schema": {
+              "type": "string",
+              "example": "healthngoadmin1"
+            }
+          },
+          {
+            "name": "request_token",
+            "in": "query",
+            "required": true,
+            "style": "form",
+            "explode": true,
+            "schema": {
+              "type": "string",
+              "example": "Organizer"
+            }
+          },
+          {
+            "name": "subscriber_id",
+            "in": "query",
+            "required": true,
+            "style": "form",
+            "explode": true,
+            "schema": {
+              "type": "string",
+              "example": "12345"
+            }
           }
-        }, {
-          "name" : "request_token",
-          "in" : "query",
-          "required" : true,
-          "style" : "form",
-          "explode" : true,
-          "schema" : {
-            "type" : "string",
-            "example" : "Organizer"
-          }
-        }, {
-          "name" : "subscriber_id",
-          "in" : "query",
-          "required" : true,
-          "style" : "form",
-          "explode" : true,
-          "schema" : {
-            "type" : "string",
-            "example" : "12345"
-          }
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "success, subscriber cancelled"
+        ],
+        "responses": {
+          "200": {
+            "description": "success, subscriber cancelled"
           },
-          "400" : {
-            "description" : "Invalid request"
+          "400": {
+            "description": "Invalid request"
           },
-          "403" : {
-            "description" : "No permission"
+          "403": {
+            "description": "No permission"
           },
-          "404" : {
-            "description" : "one or more specified inputs not found"
+          "404": {
+            "description": "one or more specified inputs not found"
           },
-          "default" : {
-            "description" : "Unexpected error"
+          "default": {
+            "description": "Unexpected error"
           }
         }
       }
     },
-    "/subscriber/list_details" : {
-      "get" : {
-        "tags" : [ "subscriber" ],
-        "summary" : "get list of entities filetered by criteria in subscriber_filter and return info specified by subscriber_details_required with success or error code",
-        "parameters" : [ {
-          "name" : "requestor_id",
-          "in" : "query",
-          "required" : true,
-          "style" : "form",
-          "explode" : true,
-          "schema" : {
-            "type" : "string",
-            "example" : "healthngoadmin1"
+    "/subscriber/list_details": {
+      "get": {
+        "tags": ["subscriber"],
+        "summary": "get list of entities filetered by criteria in subscriber_filter and return info specified by subscriber_details_required with success or error code",
+        "parameters": [
+          {
+            "name": "requestor_id",
+            "in": "query",
+            "required": true,
+            "style": "form",
+            "explode": true,
+            "schema": {
+              "type": "string",
+              "example": "healthngoadmin1"
+            }
+          },
+          {
+            "name": "request_token",
+            "in": "query",
+            "required": true,
+            "style": "form",
+            "explode": true,
+            "schema": {
+              "type": "string",
+              "example": "Organizer"
+            }
+          },
+          {
+            "name": "qry",
+            "in": "query",
+            "required": true,
+            "style": "form",
+            "explode": true,
+            "schema": {
+              "$ref": "#/components/schemas/subscriber_get_details_qry"
+            }
           }
-        }, {
-          "name" : "request_token",
-          "in" : "query",
-          "required" : true,
-          "style" : "form",
-          "explode" : true,
-          "schema" : {
-            "type" : "string",
-            "example" : "Organizer"
-          }
-        }, {
-          "name" : "qry",
-          "in" : "query",
-          "required" : true,
-          "style" : "form",
-          "explode" : true,
-          "schema" : {
-            "$ref" : "#/components/schemas/subscriber_get_details_qry"
-          }
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "success,message list",
-            "content" : {
-              "json" : {
-                "schema" : {
-                  "type" : "array",
-                  "items" : {
-                    "$ref" : "#/components/schemas/subscriber_list"
+        ],
+        "responses": {
+          "200": {
+            "description": "success,message list",
+            "content": {
+              "json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/subscriber_list"
                   }
                 }
               }
             }
           },
-          "400" : {
-            "description" : "Invalid request"
+          "400": {
+            "description": "Invalid request"
           },
-          "403" : {
-            "description" : "No permission"
+          "403": {
+            "description": "No permission"
           },
-          "404" : {
-            "description" : "one or more specified inputs not found"
+          "404": {
+            "description": "one or more specified inputs not found"
           },
-          "default" : {
-            "description" : "Unexpected error"
+          "default": {
+            "description": "Unexpected error"
           }
         }
       }
     },
-    "/message/new" : {
-      "post" : {
-        "tags" : [ "message" ],
-        "summary" : "create a new message, in message_list with given message_details, returns new message id or  error code",
-        "parameters" : [ {
-          "name" : "requestor_id",
-          "in" : "query",
-          "required" : true,
-          "style" : "form",
-          "explode" : true,
-          "schema" : {
-            "type" : "string",
-            "example" : "healthngoadmin1"
+    "/message/new": {
+      "post": {
+        "tags": ["message"],
+        "summary": "create a new message, in message_list with given message_details, returns new message id or  error code",
+        "parameters": [
+          {
+            "name": "requestor_id",
+            "in": "query",
+            "required": true,
+            "style": "form",
+            "explode": true,
+            "schema": {
+              "type": "string",
+              "example": "healthngoadmin1"
+            }
+          },
+          {
+            "name": "request_token",
+            "in": "query",
+            "required": true,
+            "style": "form",
+            "explode": true,
+            "schema": {
+              "type": "string",
+              "example": "Organizer"
+            }
+          },
+          {
+            "name": "qry",
+            "in": "query",
+            "required": true,
+            "style": "form",
+            "explode": true,
+            "schema": {
+              "$ref": "#/components/schemas/message_new_qry"
+            }
           }
-        }, {
-          "name" : "request_token",
-          "in" : "query",
-          "required" : true,
-          "style" : "form",
-          "explode" : true,
-          "schema" : {
-            "type" : "string",
-            "example" : "Organizer"
-          }
-        }, {
-          "name" : "qry",
-          "in" : "query",
-          "required" : true,
-          "style" : "form",
-          "explode" : true,
-          "schema" : {
-            "$ref" : "#/components/schemas/message_new_qry"
-          }
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "success",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "type" : "string",
-                  "description" : "ID of created message",
-                  "example" : "message_name:xyz hospital,message_id:1"
+        ],
+        "responses": {
+          "200": {
+            "description": "success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string",
+                  "description": "ID of created message",
+                  "example": "message_name:xyz hospital,message_id:1"
                 }
               }
             }
           },
-          "400" : {
-            "description" : "Invalid request"
+          "400": {
+            "description": "Invalid request"
           },
-          "403" : {
-            "description" : "No permission"
+          "403": {
+            "description": "No permission"
           },
-          "404" : {
-            "description" : "one or more specified inputs not found"
+          "404": {
+            "description": "one or more specified inputs not found"
           },
-          "default" : {
-            "description" : "Unexpected error"
+          "default": {
+            "description": "Unexpected error"
           }
         }
       }
     },
-    "/message/modifications" : {
-      "put" : {
-        "tags" : [ "message" ],
-        "summary" : "changes values of specific details (as given by message_details) of given message (selected by message_filter)in message_list and returns success or error code",
-        "parameters" : [ {
-          "name" : "requestor_id",
-          "in" : "query",
-          "required" : true,
-          "style" : "form",
-          "explode" : true,
-          "schema" : {
-            "type" : "string",
-            "example" : "healthngoadmin1"
-          }
-        }, {
-          "name" : "request_token",
-          "in" : "query",
-          "required" : true,
-          "style" : "form",
-          "explode" : true,
-          "schema" : {
-            "type" : "string",
-            "example" : "Organizer"
-          }
-        }, {
-          "name" : "message_id",
-          "in" : "query",
-          "required" : true,
-          "style" : "form",
-          "explode" : true,
-          "schema" : {
-            "type" : "string",
-            "example" : "1"
-          }
-        }, {
-          "name" : "qry",
-          "in" : "query",
-          "required" : true,
-          "style" : "form",
-          "explode" : true,
-          "schema" : {
-            "$ref" : "#/components/schemas/message_modify_qry"
-          }
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "success, message updated"
+    "/message/modifications": {
+      "put": {
+        "tags": ["message"],
+        "summary": "changes values of specific details (as given by message_details) of given message (selected by message_filter)in message_list and returns success or error code",
+        "parameters": [
+          {
+            "name": "requestor_id",
+            "in": "query",
+            "required": true,
+            "style": "form",
+            "explode": true,
+            "schema": {
+              "type": "string",
+              "example": "healthngoadmin1"
+            }
           },
-          "400" : {
-            "description" : "Invalid request"
+          {
+            "name": "request_token",
+            "in": "query",
+            "required": true,
+            "style": "form",
+            "explode": true,
+            "schema": {
+              "type": "string",
+              "example": "Organizer"
+            }
           },
-          "403" : {
-            "description" : "No permission"
+          {
+            "name": "message_id",
+            "in": "query",
+            "required": true,
+            "style": "form",
+            "explode": true,
+            "schema": {
+              "type": "string",
+              "example": "1"
+            }
           },
-          "404" : {
-            "description" : "one or more specified inputs not found"
+          {
+            "name": "qry",
+            "in": "query",
+            "required": true,
+            "style": "form",
+            "explode": true,
+            "schema": {
+              "$ref": "#/components/schemas/message_modify_qry"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "success, message updated"
           },
-          "default" : {
-            "description" : "Unexpected error"
+          "400": {
+            "description": "Invalid request"
+          },
+          "403": {
+            "description": "No permission"
+          },
+          "404": {
+            "description": "one or more specified inputs not found"
+          },
+          "default": {
+            "description": "Unexpected error"
           }
         }
       }
     },
-    "/message" : {
-      "delete" : {
-        "tags" : [ "message" ],
-        "summary" : "delete a predefined message in message_list and returns success or error code",
-        "parameters" : [ {
-          "name" : "requestor_id",
-          "in" : "query",
-          "required" : true,
-          "style" : "form",
-          "explode" : true,
-          "schema" : {
-            "type" : "string",
-            "example" : "healthngoadmin1"
+    "/message": {
+      "delete": {
+        "tags": ["message"],
+        "summary": "delete a predefined message in message_list and returns success or error code",
+        "parameters": [
+          {
+            "name": "requestor_id",
+            "in": "query",
+            "required": true,
+            "style": "form",
+            "explode": true,
+            "schema": {
+              "type": "string",
+              "example": "healthngoadmin1"
+            }
+          },
+          {
+            "name": "request_token",
+            "in": "query",
+            "required": true,
+            "style": "form",
+            "explode": true,
+            "schema": {
+              "type": "string",
+              "example": "Organizer"
+            }
+          },
+          {
+            "name": "message_id",
+            "in": "query",
+            "required": true,
+            "style": "form",
+            "explode": true,
+            "schema": {
+              "type": "string",
+              "example": "1"
+            }
           }
-        }, {
-          "name" : "request_token",
-          "in" : "query",
-          "required" : true,
-          "style" : "form",
-          "explode" : true,
-          "schema" : {
-            "type" : "string",
-            "example" : "Organizer"
-          }
-        }, {
-          "name" : "message_id",
-          "in" : "query",
-          "required" : true,
-          "style" : "form",
-          "explode" : true,
-          "schema" : {
-            "type" : "string",
-            "example" : "1"
-          }
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "success, message cancelled"
+        ],
+        "responses": {
+          "200": {
+            "description": "success, message cancelled"
           },
-          "400" : {
-            "description" : "Invalid request"
+          "400": {
+            "description": "Invalid request"
           },
-          "403" : {
-            "description" : "No permission"
+          "403": {
+            "description": "No permission"
           },
-          "404" : {
-            "description" : "one or more specified inputs not found"
+          "404": {
+            "description": "one or more specified inputs not found"
           },
-          "default" : {
-            "description" : "Unexpected error"
+          "default": {
+            "description": "Unexpected error"
           }
         }
       }
     },
-    "/message/list_details" : {
-      "get" : {
-        "tags" : [ "message" ],
-        "summary" : "get list of entities filetered by criteria in message_filter and return info specified by message_details_required with success or error code",
-        "parameters" : [ {
-          "name" : "requestor_id",
-          "in" : "query",
-          "required" : true,
-          "style" : "form",
-          "explode" : true,
-          "schema" : {
-            "type" : "string",
-            "example" : "healthngoadmin1"
+    "/message/list_details": {
+      "get": {
+        "tags": ["message"],
+        "summary": "get list of entities filetered by criteria in message_filter and return info specified by message_details_required with success or error code",
+        "parameters": [
+          {
+            "name": "requestor_id",
+            "in": "query",
+            "required": true,
+            "style": "form",
+            "explode": true,
+            "schema": {
+              "type": "string",
+              "example": "healthngoadmin1"
+            }
+          },
+          {
+            "name": "request_token",
+            "in": "query",
+            "required": true,
+            "style": "form",
+            "explode": true,
+            "schema": {
+              "type": "string",
+              "example": "Organizer"
+            }
+          },
+          {
+            "name": "qry",
+            "in": "query",
+            "required": true,
+            "style": "form",
+            "explode": true,
+            "schema": {
+              "$ref": "#/components/schemas/message_get_details_qry"
+            }
           }
-        }, {
-          "name" : "request_token",
-          "in" : "query",
-          "required" : true,
-          "style" : "form",
-          "explode" : true,
-          "schema" : {
-            "type" : "string",
-            "example" : "Organizer"
-          }
-        }, {
-          "name" : "qry",
-          "in" : "query",
-          "required" : true,
-          "style" : "form",
-          "explode" : true,
-          "schema" : {
-            "$ref" : "#/components/schemas/message_get_details_qry"
-          }
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "success,message list",
-            "content" : {
-              "json" : {
-                "schema" : {
-                  "type" : "array",
-                  "items" : {
-                    "$ref" : "#/components/schemas/message_list"
+        ],
+        "responses": {
+          "200": {
+            "description": "success,message list",
+            "content": {
+              "json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/message_list"
                   }
                 }
               }
             }
           },
-          "400" : {
-            "description" : "Invalid request"
+          "400": {
+            "description": "Invalid request"
           },
-          "403" : {
-            "description" : "No permission"
+          "403": {
+            "description": "No permission"
           },
-          "404" : {
-            "description" : "one or more specified inputs not found"
+          "404": {
+            "description": "one or more specified inputs not found"
           },
-          "default" : {
-            "description" : "Unexpected error"
+          "default": {
+            "description": "Unexpected error"
           }
         }
       }
     },
-    "/affiliation/new" : {
-      "post" : {
-        "tags" : [ "affiliation" ],
-        "summary" : "create a new affiliation, in affiliation_list with given affiliation_details, returns new affiliation id or  error code",
-        "parameters" : [ {
-          "name" : "requestor_id",
-          "in" : "query",
-          "required" : true,
-          "style" : "form",
-          "explode" : true,
-          "schema" : {
-            "type" : "string",
-            "example" : "healthngoadmin1"
+    "/affiliation/new": {
+      "post": {
+        "tags": ["affiliation"],
+        "summary": "create a new affiliation, in affiliation_list with given affiliation_details, returns new affiliation id or  error code",
+        "parameters": [
+          {
+            "name": "requestor_id",
+            "in": "query",
+            "required": true,
+            "style": "form",
+            "explode": true,
+            "schema": {
+              "type": "string",
+              "example": "healthngoadmin1"
+            }
+          },
+          {
+            "name": "request_token",
+            "in": "query",
+            "required": true,
+            "style": "form",
+            "explode": true,
+            "schema": {
+              "type": "string",
+              "example": "Organizer"
+            }
+          },
+          {
+            "name": "qry",
+            "in": "query",
+            "required": true,
+            "style": "form",
+            "explode": true,
+            "schema": {
+              "$ref": "#/components/schemas/affiliation_new_qry"
+            }
           }
-        }, {
-          "name" : "request_token",
-          "in" : "query",
-          "required" : true,
-          "style" : "form",
-          "explode" : true,
-          "schema" : {
-            "type" : "string",
-            "example" : "Organizer"
-          }
-        }, {
-          "name" : "qry",
-          "in" : "query",
-          "required" : true,
-          "style" : "form",
-          "explode" : true,
-          "schema" : {
-            "$ref" : "#/components/schemas/affiliation_new_qry"
-          }
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "success",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "type" : "string",
-                  "description" : "ID of created affiliation",
-                  "example" : "affiliation_name:xyz hospital,affiliation_id:1"
+        ],
+        "responses": {
+          "200": {
+            "description": "success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string",
+                  "description": "ID of created affiliation",
+                  "example": "affiliation_name:xyz hospital,affiliation_id:1"
                 }
               }
             }
           },
-          "400" : {
-            "description" : "Invalid request"
+          "400": {
+            "description": "Invalid request"
           },
-          "403" : {
-            "description" : "No permission"
+          "403": {
+            "description": "No permission"
           },
-          "404" : {
-            "description" : "one or more specified inputs not found"
+          "404": {
+            "description": "one or more specified inputs not found"
           },
-          "default" : {
-            "description" : "Unexpected error"
+          "default": {
+            "description": "Unexpected error"
           }
         }
       }
     },
-    "/affiliation/modifications" : {
-      "put" : {
-        "tags" : [ "affiliation" ],
-        "summary" : "changes values of specific details (as given by affiliation_details) of given affiliation (selected by affiliation_filter)in affiliation_list and returns success or error code",
-        "parameters" : [ {
-          "name" : "requestor_id",
-          "in" : "query",
-          "required" : true,
-          "style" : "form",
-          "explode" : true,
-          "schema" : {
-            "type" : "string",
-            "example" : "healthngoadmin1"
-          }
-        }, {
-          "name" : "request_token",
-          "in" : "query",
-          "required" : true,
-          "style" : "form",
-          "explode" : true,
-          "schema" : {
-            "type" : "string",
-            "example" : "Organizer"
-          }
-        }, {
-          "name" : "affiliation_id",
-          "in" : "query",
-          "required" : true,
-          "style" : "form",
-          "explode" : true,
-          "schema" : {
-            "type" : "string",
-            "example" : "1"
-          }
-        }, {
-          "name" : "qry",
-          "in" : "query",
-          "required" : true,
-          "style" : "form",
-          "explode" : true,
-          "schema" : {
-            "$ref" : "#/components/schemas/affiliation_modify_qry"
-          }
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "success, affiliation updated"
+    "/affiliation/modifications": {
+      "put": {
+        "tags": ["affiliation"],
+        "summary": "changes values of specific details (as given by affiliation_details) of given affiliation (selected by affiliation_filter)in affiliation_list and returns success or error code",
+        "parameters": [
+          {
+            "name": "requestor_id",
+            "in": "query",
+            "required": true,
+            "style": "form",
+            "explode": true,
+            "schema": {
+              "type": "string",
+              "example": "healthngoadmin1"
+            }
           },
-          "400" : {
-            "description" : "Invalid request"
+          {
+            "name": "request_token",
+            "in": "query",
+            "required": true,
+            "style": "form",
+            "explode": true,
+            "schema": {
+              "type": "string",
+              "example": "Organizer"
+            }
           },
-          "403" : {
-            "description" : "No permission"
+          {
+            "name": "affiliation_id",
+            "in": "query",
+            "required": true,
+            "style": "form",
+            "explode": true,
+            "schema": {
+              "type": "string",
+              "example": "1"
+            }
           },
-          "404" : {
-            "description" : "one or more specified inputs not found"
+          {
+            "name": "qry",
+            "in": "query",
+            "required": true,
+            "style": "form",
+            "explode": true,
+            "schema": {
+              "$ref": "#/components/schemas/affiliation_modify_qry"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "success, affiliation updated"
           },
-          "default" : {
-            "description" : "Unexpected error"
+          "400": {
+            "description": "Invalid request"
+          },
+          "403": {
+            "description": "No permission"
+          },
+          "404": {
+            "description": "one or more specified inputs not found"
+          },
+          "default": {
+            "description": "Unexpected error"
           }
         }
       }
     },
-    "/affiliation" : {
-      "delete" : {
-        "tags" : [ "affiliation" ],
-        "summary" : "delete a predefined affiliation in affiliation_list and returns success or error code",
-        "parameters" : [ {
-          "name" : "requestor_id",
-          "in" : "query",
-          "required" : true,
-          "style" : "form",
-          "explode" : true,
-          "schema" : {
-            "type" : "string",
-            "example" : "healthngoadmin1"
+    "/affiliation": {
+      "delete": {
+        "tags": ["affiliation"],
+        "summary": "delete a predefined affiliation in affiliation_list and returns success or error code",
+        "parameters": [
+          {
+            "name": "requestor_id",
+            "in": "query",
+            "required": true,
+            "style": "form",
+            "explode": true,
+            "schema": {
+              "type": "string",
+              "example": "healthngoadmin1"
+            }
+          },
+          {
+            "name": "request_token",
+            "in": "query",
+            "required": true,
+            "style": "form",
+            "explode": true,
+            "schema": {
+              "type": "string",
+              "example": "Organizer"
+            }
+          },
+          {
+            "name": "affiliation_id",
+            "in": "query",
+            "required": true,
+            "style": "form",
+            "explode": true,
+            "schema": {
+              "type": "string",
+              "example": "1"
+            }
           }
-        }, {
-          "name" : "request_token",
-          "in" : "query",
-          "required" : true,
-          "style" : "form",
-          "explode" : true,
-          "schema" : {
-            "type" : "string",
-            "example" : "Organizer"
-          }
-        }, {
-          "name" : "affiliation_id",
-          "in" : "query",
-          "required" : true,
-          "style" : "form",
-          "explode" : true,
-          "schema" : {
-            "type" : "string",
-            "example" : "1"
-          }
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "success, affiliation cancelled"
+        ],
+        "responses": {
+          "200": {
+            "description": "success, affiliation cancelled"
           },
-          "400" : {
-            "description" : "Invalid request"
+          "400": {
+            "description": "Invalid request"
           },
-          "403" : {
-            "description" : "No permission"
+          "403": {
+            "description": "No permission"
           },
-          "404" : {
-            "description" : "one or more specified inputs not found"
+          "404": {
+            "description": "one or more specified inputs not found"
           },
-          "default" : {
-            "description" : "Unexpected error"
+          "default": {
+            "description": "Unexpected error"
           }
         }
       }
     },
-    "/affiliation/list_details" : {
-      "get" : {
-        "tags" : [ "affiliation" ],
-        "summary" : "get list of entities filetered by criteria in affiliation_filter and return info specified by affiliation_details_required with success or error code",
-        "parameters" : [ {
-          "name" : "requestor_id",
-          "in" : "query",
-          "required" : true,
-          "style" : "form",
-          "explode" : true,
-          "schema" : {
-            "type" : "string",
-            "example" : "healthngoadmin1"
+    "/affiliation/list_details": {
+      "get": {
+        "tags": ["affiliation"],
+        "summary": "get list of entities filetered by criteria in affiliation_filter and return info specified by affiliation_details_required with success or error code",
+        "parameters": [
+          {
+            "name": "requestor_id",
+            "in": "query",
+            "required": true,
+            "style": "form",
+            "explode": true,
+            "schema": {
+              "type": "string",
+              "example": "healthngoadmin1"
+            }
+          },
+          {
+            "name": "request_token",
+            "in": "query",
+            "required": true,
+            "style": "form",
+            "explode": true,
+            "schema": {
+              "type": "string",
+              "example": "Organizer"
+            }
+          },
+          {
+            "name": "qry",
+            "in": "query",
+            "required": true,
+            "style": "form",
+            "explode": true,
+            "schema": {
+              "$ref": "#/components/schemas/affiliation_get_details_qry"
+            }
           }
-        }, {
-          "name" : "request_token",
-          "in" : "query",
-          "required" : true,
-          "style" : "form",
-          "explode" : true,
-          "schema" : {
-            "type" : "string",
-            "example" : "Organizer"
-          }
-        }, {
-          "name" : "qry",
-          "in" : "query",
-          "required" : true,
-          "style" : "form",
-          "explode" : true,
-          "schema" : {
-            "$ref" : "#/components/schemas/affiliation_get_details_qry"
-          }
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "success,affiliation list",
-            "content" : {
-              "json" : {
-                "schema" : {
-                  "type" : "array",
-                  "items" : {
-                    "$ref" : "#/components/schemas/affiliation_list"
+        ],
+        "responses": {
+          "200": {
+            "description": "success,affiliation list",
+            "content": {
+              "json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/affiliation_list"
                   }
                 }
               }
             }
           },
-          "400" : {
-            "description" : "Invalid request"
+          "400": {
+            "description": "Invalid request"
           },
-          "403" : {
-            "description" : "No permission"
+          "403": {
+            "description": "No permission"
           },
-          "404" : {
-            "description" : "one or more specified inputs not found"
+          "404": {
+            "description": "one or more specified inputs not found"
           },
-          "default" : {
-            "description" : "Unexpected error"
+          "default": {
+            "description": "Unexpected error"
           }
         }
       }
     },
-    "/alert_schedule/new" : {
-      "post" : {
-        "tags" : [ "alert_schedule" ],
-        "summary" : "create a new alert_schedule, in alert_schedule_list with given alert_schedule_details, returns new alert_schedule id or  error code",
-        "parameters" : [ {
-          "name" : "requestor_id",
-          "in" : "query",
-          "required" : true,
-          "style" : "form",
-          "explode" : true,
-          "schema" : {
-            "type" : "string",
-            "example" : "healthngoadmin1"
+    "/alert_schedule/new": {
+      "post": {
+        "tags": ["alert_schedule"],
+        "summary": "create a new alert_schedule, in alert_schedule_list with given alert_schedule_details, returns new alert_schedule id or  error code",
+        "parameters": [
+          {
+            "name": "requestor_id",
+            "in": "query",
+            "required": true,
+            "style": "form",
+            "explode": true,
+            "schema": {
+              "type": "string",
+              "example": "healthngoadmin1"
+            }
+          },
+          {
+            "name": "request_token",
+            "in": "query",
+            "required": true,
+            "style": "form",
+            "explode": true,
+            "schema": {
+              "type": "string",
+              "example": "Organizer"
+            }
+          },
+          {
+            "name": "qry",
+            "in": "query",
+            "required": true,
+            "style": "form",
+            "explode": true,
+            "schema": {
+              "$ref": "#/components/schemas/alert_schedule_new_qry"
+            }
           }
-        }, {
-          "name" : "request_token",
-          "in" : "query",
-          "required" : true,
-          "style" : "form",
-          "explode" : true,
-          "schema" : {
-            "type" : "string",
-            "example" : "Organizer"
-          }
-        }, {
-          "name" : "qry",
-          "in" : "query",
-          "required" : true,
-          "style" : "form",
-          "explode" : true,
-          "schema" : {
-            "$ref" : "#/components/schemas/alert_schedule_new_qry"
-          }
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "success",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "type" : "string",
-                  "description" : "ID of created alert_schedule",
-                  "example" : "alert_schedule_name:xyz hospital,alert_schedule_id:1"
+        ],
+        "responses": {
+          "200": {
+            "description": "success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string",
+                  "description": "ID of created alert_schedule",
+                  "example": "alert_schedule_name:xyz hospital,alert_schedule_id:1"
                 }
               }
             }
           },
-          "400" : {
-            "description" : "Invalid request"
+          "400": {
+            "description": "Invalid request"
           },
-          "403" : {
-            "description" : "No permission"
+          "403": {
+            "description": "No permission"
           },
-          "404" : {
-            "description" : "one or more specified inputs not found"
+          "404": {
+            "description": "one or more specified inputs not found"
           },
-          "default" : {
-            "description" : "Unexpected error"
+          "default": {
+            "description": "Unexpected error"
           }
         }
       }
     },
-    "/alert_schedule/modifications" : {
-      "put" : {
-        "tags" : [ "alert_schedule" ],
-        "summary" : "changes values of specific details (as given by alert_schedule_details) of given alert_schedule (selected by alert_schedule_filter)in alert_schedule_list and returns success or error code",
-        "parameters" : [ {
-          "name" : "requestor_id",
-          "in" : "query",
-          "required" : true,
-          "style" : "form",
-          "explode" : true,
-          "schema" : {
-            "type" : "string",
-            "example" : "healthngoadmin1"
+    "/alert_schedule/modifications": {
+      "put": {
+        "tags": ["alert_schedule"],
+        "summary": "changes values of specific details (as given by alert_schedule_details) of given alert_schedule (selected by alert_schedule_filter)in alert_schedule_list and returns success or error code",
+        "parameters": [
+          {
+            "name": "requestor_id",
+            "in": "query",
+            "required": true,
+            "style": "form",
+            "explode": true,
+            "schema": {
+              "type": "string",
+              "example": "healthngoadmin1"
+            }
+          },
+          {
+            "name": "request_token",
+            "in": "query",
+            "required": true,
+            "style": "form",
+            "explode": true,
+            "schema": {
+              "type": "string"
+            },
+            "example": "Organizer"
+          },
+          {
+            "name": "alert_schedule_id",
+            "in": "query",
+            "required": true,
+            "style": "form",
+            "explode": true,
+            "schema": {
+              "type": "string",
+              "example": "1"
+            }
+          },
+          {
+            "name": "qry",
+            "in": "query",
+            "required": true,
+            "style": "form",
+            "explode": true,
+            "schema": {
+              "$ref": "#/components/schemas/alert_schedule_modify_qry"
+            }
           }
-        }, {
-          "name" : "request_token",
-          "in" : "query",
-          "required" : true,
-          "style" : "form",
-          "explode" : true,
-          "schema" : {
-            "type" : "string"
+        ],
+        "responses": {
+          "200": {
+            "description": "success, alert_schedule updated"
           },
-          "example" : "Organizer"
-        }, {
-          "name" : "alert_schedule_id",
-          "in" : "query",
-          "required" : true,
-          "style" : "form",
-          "explode" : true,
-          "schema" : {
-            "type" : "string",
-            "example" : "1"
-          }
-        }, {
-          "name" : "qry",
-          "in" : "query",
-          "required" : true,
-          "style" : "form",
-          "explode" : true,
-          "schema" : {
-            "$ref" : "#/components/schemas/alert_schedule_modify_qry"
-          }
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "success, alert_schedule updated"
+          "400": {
+            "description": "Invalid request"
           },
-          "400" : {
-            "description" : "Invalid request"
+          "403": {
+            "description": "No permission"
           },
-          "403" : {
-            "description" : "No permission"
+          "404": {
+            "description": "one or more specified inputs not found"
           },
-          "404" : {
-            "description" : "one or more specified inputs not found"
-          },
-          "default" : {
-            "description" : "Unexpected error"
+          "default": {
+            "description": "Unexpected error"
           }
         }
       }
     },
-    "/alert_schedule" : {
-      "delete" : {
-        "tags" : [ "alert_schedule" ],
-        "summary" : "delete a predefined alert_schedule in alert_schedule_list and returns success or error code",
-        "parameters" : [ {
-          "name" : "requestor_id",
-          "in" : "query",
-          "required" : true,
-          "style" : "form",
-          "explode" : true,
-          "schema" : {
-            "type" : "string",
-            "example" : "healthngoadmin1"
+    "/alert_schedule": {
+      "delete": {
+        "tags": ["alert_schedule"],
+        "summary": "delete a predefined alert_schedule in alert_schedule_list and returns success or error code",
+        "parameters": [
+          {
+            "name": "requestor_id",
+            "in": "query",
+            "required": true,
+            "style": "form",
+            "explode": true,
+            "schema": {
+              "type": "string",
+              "example": "healthngoadmin1"
+            }
+          },
+          {
+            "name": "request_token",
+            "in": "query",
+            "required": true,
+            "style": "form",
+            "explode": true,
+            "schema": {
+              "type": "string",
+              "example": "Organizer"
+            }
+          },
+          {
+            "name": "alert_schedule_id",
+            "in": "query",
+            "required": true,
+            "style": "form",
+            "explode": true,
+            "schema": {
+              "type": "string",
+              "example": "1"
+            }
           }
-        }, {
-          "name" : "request_token",
-          "in" : "query",
-          "required" : true,
-          "style" : "form",
-          "explode" : true,
-          "schema" : {
-            "type" : "string",
-            "example" : "Organizer"
-          }
-        }, {
-          "name" : "alert_schedule_id",
-          "in" : "query",
-          "required" : true,
-          "style" : "form",
-          "explode" : true,
-          "schema" : {
-            "type" : "string",
-            "example" : "1"
-          }
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "success, alert_schedule cancelled"
+        ],
+        "responses": {
+          "200": {
+            "description": "success, alert_schedule cancelled"
           },
-          "400" : {
-            "description" : "Invalid request"
+          "400": {
+            "description": "Invalid request"
           },
-          "403" : {
-            "description" : "No permission"
+          "403": {
+            "description": "No permission"
           },
-          "404" : {
-            "description" : "one or more specified inputs not found"
+          "404": {
+            "description": "one or more specified inputs not found"
           },
-          "default" : {
-            "description" : "Unexpected error"
+          "default": {
+            "description": "Unexpected error"
           }
         }
       }
     },
-    "/alert_schedule/list_details" : {
-      "get" : {
-        "tags" : [ "alert_schedule" ],
-        "summary" : "get list of entities filetered by criteria in alert_schedule_filter and return info specified by alert_schedule_details_required with success or error code",
-        "parameters" : [ {
-          "name" : "requestor_id",
-          "in" : "query",
-          "required" : true,
-          "style" : "form",
-          "explode" : true,
-          "schema" : {
-            "type" : "string",
-            "example" : "healthngoadmin1"
+    "/alert_schedule/list_details": {
+      "get": {
+        "tags": ["alert_schedule"],
+        "summary": "get list of entities filetered by criteria in alert_schedule_filter and return info specified by alert_schedule_details_required with success or error code",
+        "parameters": [
+          {
+            "name": "requestor_id",
+            "in": "query",
+            "required": true,
+            "style": "form",
+            "explode": true,
+            "schema": {
+              "type": "string",
+              "example": "healthngoadmin1"
+            }
+          },
+          {
+            "name": "request_token",
+            "in": "query",
+            "required": true,
+            "style": "form",
+            "explode": true,
+            "schema": {
+              "type": "string",
+              "example": "Organizer"
+            }
+          },
+          {
+            "name": "qry",
+            "in": "query",
+            "required": true,
+            "style": "form",
+            "explode": true,
+            "schema": {
+              "$ref": "#/components/schemas/alert_schedule_get_details_qry"
+            }
           }
-        }, {
-          "name" : "request_token",
-          "in" : "query",
-          "required" : true,
-          "style" : "form",
-          "explode" : true,
-          "schema" : {
-            "type" : "string",
-            "example" : "Organizer"
-          }
-        }, {
-          "name" : "qry",
-          "in" : "query",
-          "required" : true,
-          "style" : "form",
-          "explode" : true,
-          "schema" : {
-            "$ref" : "#/components/schemas/alert_schedule_get_details_qry"
-          }
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "success,alert_schedule list",
-            "content" : {
-              "json" : {
-                "schema" : {
-                  "type" : "array",
-                  "items" : {
-                    "$ref" : "#/components/schemas/alert_schedule_list"
+        ],
+        "responses": {
+          "200": {
+            "description": "success,alert_schedule list",
+            "content": {
+              "json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/alert_schedule_list"
                   }
                 }
               }
             }
           },
-          "400" : {
-            "description" : "Invalid request"
+          "400": {
+            "description": "Invalid request"
           },
-          "403" : {
-            "description" : "No permission"
+          "403": {
+            "description": "No permission"
           },
-          "404" : {
-            "description" : "one or more specified inputs not found"
+          "404": {
+            "description": "one or more specified inputs not found"
           },
-          "default" : {
-            "description" : "Unexpected error"
+          "default": {
+            "description": "Unexpected error"
           }
         }
       }
     },
-    "/log/new" : {
-      "post" : {
-        "tags" : [ "log" ],
-        "summary" : "create a new log, in log_list with given log_details, returns new log id or  error code",
-        "parameters" : [ {
-          "name" : "requestor_id",
-          "in" : "query",
-          "required" : true,
-          "style" : "form",
-          "explode" : true,
-          "schema" : {
-            "type" : "string",
-            "example" : "healthngoadmin1"
+    "/log/new": {
+      "post": {
+        "tags": ["log"],
+        "summary": "create a new log, in log_list with given log_details, returns new log id or  error code",
+        "parameters": [
+          {
+            "name": "requestor_id",
+            "in": "query",
+            "required": true,
+            "style": "form",
+            "explode": true,
+            "schema": {
+              "type": "string",
+              "example": "healthngoadmin1"
+            }
+          },
+          {
+            "name": "request_token",
+            "in": "query",
+            "required": true,
+            "style": "form",
+            "explode": true,
+            "schema": {
+              "type": "string",
+              "example": "Organizer"
+            }
+          },
+          {
+            "name": "qry",
+            "in": "query",
+            "required": true,
+            "style": "form",
+            "explode": true,
+            "schema": {
+              "$ref": "#/components/schemas/log_new_qry"
+            }
           }
-        }, {
-          "name" : "request_token",
-          "in" : "query",
-          "required" : true,
-          "style" : "form",
-          "explode" : true,
-          "schema" : {
-            "type" : "string",
-            "example" : "Organizer"
-          }
-        }, {
-          "name" : "qry",
-          "in" : "query",
-          "required" : true,
-          "style" : "form",
-          "explode" : true,
-          "schema" : {
-            "$ref" : "#/components/schemas/log_new_qry"
-          }
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "success",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "type" : "string",
-                  "description" : "ID of created log",
-                  "example" : "log_name:xyz hospital,log_id:1"
+        ],
+        "responses": {
+          "200": {
+            "description": "success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string",
+                  "description": "ID of created log",
+                  "example": "log_name:xyz hospital,log_id:1"
                 }
               }
             }
           },
-          "400" : {
-            "description" : "Invalid request"
+          "400": {
+            "description": "Invalid request"
           },
-          "403" : {
-            "description" : "No permission"
+          "403": {
+            "description": "No permission"
           },
-          "404" : {
-            "description" : "one or more specified inputs not found"
+          "404": {
+            "description": "one or more specified inputs not found"
           },
-          "default" : {
-            "description" : "Unexpected error"
+          "default": {
+            "description": "Unexpected error"
           }
         }
       }
     },
-    "/log/modifications" : {
-      "put" : {
-        "tags" : [ "log" ],
-        "summary" : "changes values of specific details (as given by log_details) of given log (selected by log_filter)in log_list and returns success or error code",
-        "parameters" : [ {
-          "name" : "requestor_id",
-          "in" : "query",
-          "required" : true,
-          "style" : "form",
-          "explode" : true,
-          "schema" : {
-            "type" : "string",
-            "example" : "healthngoadmin1"
-          }
-        }, {
-          "name" : "request_token",
-          "in" : "query",
-          "required" : true,
-          "style" : "form",
-          "explode" : true,
-          "schema" : {
-            "type" : "string",
-            "example" : "Organizer"
-          }
-        }, {
-          "name" : "log_id",
-          "in" : "query",
-          "required" : true,
-          "style" : "form",
-          "explode" : true,
-          "schema" : {
-            "type" : "string",
-            "example" : "1"
-          }
-        }, {
-          "name" : "qry",
-          "in" : "query",
-          "required" : true,
-          "style" : "form",
-          "explode" : true,
-          "schema" : {
-            "$ref" : "#/components/schemas/log_modify_qry"
-          }
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "success, log updated"
+    "/log/modifications": {
+      "put": {
+        "tags": ["log"],
+        "summary": "changes values of specific details (as given by log_details) of given log (selected by log_filter)in log_list and returns success or error code",
+        "parameters": [
+          {
+            "name": "requestor_id",
+            "in": "query",
+            "required": true,
+            "style": "form",
+            "explode": true,
+            "schema": {
+              "type": "string",
+              "example": "healthngoadmin1"
+            }
           },
-          "400" : {
-            "description" : "Invalid request"
+          {
+            "name": "request_token",
+            "in": "query",
+            "required": true,
+            "style": "form",
+            "explode": true,
+            "schema": {
+              "type": "string",
+              "example": "Organizer"
+            }
           },
-          "403" : {
-            "description" : "No permission"
+          {
+            "name": "log_id",
+            "in": "query",
+            "required": true,
+            "style": "form",
+            "explode": true,
+            "schema": {
+              "type": "string",
+              "example": "1"
+            }
           },
-          "404" : {
-            "description" : "one or more specified inputs not found"
+          {
+            "name": "qry",
+            "in": "query",
+            "required": true,
+            "style": "form",
+            "explode": true,
+            "schema": {
+              "$ref": "#/components/schemas/log_modify_qry"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "success, log updated"
           },
-          "default" : {
-            "description" : "Unexpected error"
+          "400": {
+            "description": "Invalid request"
+          },
+          "403": {
+            "description": "No permission"
+          },
+          "404": {
+            "description": "one or more specified inputs not found"
+          },
+          "default": {
+            "description": "Unexpected error"
           }
         }
       }
     },
-    "/log" : {
-      "delete" : {
-        "tags" : [ "log" ],
-        "summary" : "delete a predefined log in log_list and returns success or error code",
-        "parameters" : [ {
-          "name" : "requestor_id",
-          "in" : "query",
-          "required" : true,
-          "style" : "form",
-          "explode" : true,
-          "schema" : {
-            "type" : "string",
-            "example" : "healthngoadmin1"
+    "/log": {
+      "delete": {
+        "tags": ["log"],
+        "summary": "delete a predefined log in log_list and returns success or error code",
+        "parameters": [
+          {
+            "name": "requestor_id",
+            "in": "query",
+            "required": true,
+            "style": "form",
+            "explode": true,
+            "schema": {
+              "type": "string",
+              "example": "healthngoadmin1"
+            }
+          },
+          {
+            "name": "request_token",
+            "in": "query",
+            "required": true,
+            "style": "form",
+            "explode": true,
+            "schema": {
+              "type": "string",
+              "example": "Organizer"
+            }
+          },
+          {
+            "name": "log_id",
+            "in": "query",
+            "required": true,
+            "style": "form",
+            "explode": true,
+            "schema": {
+              "type": "string",
+              "example": "1"
+            }
           }
-        }, {
-          "name" : "request_token",
-          "in" : "query",
-          "required" : true,
-          "style" : "form",
-          "explode" : true,
-          "schema" : {
-            "type" : "string",
-            "example" : "Organizer"
-          }
-        }, {
-          "name" : "log_id",
-          "in" : "query",
-          "required" : true,
-          "style" : "form",
-          "explode" : true,
-          "schema" : {
-            "type" : "string",
-            "example" : "1"
-          }
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "success, log cancelled"
+        ],
+        "responses": {
+          "200": {
+            "description": "success, log cancelled"
           },
-          "400" : {
-            "description" : "Invalid request"
+          "400": {
+            "description": "Invalid request"
           },
-          "403" : {
-            "description" : "No permission"
+          "403": {
+            "description": "No permission"
           },
-          "404" : {
-            "description" : "one or more specified inputs not found"
+          "404": {
+            "description": "one or more specified inputs not found"
           },
-          "default" : {
-            "description" : "Unexpected error"
+          "default": {
+            "description": "Unexpected error"
           }
         }
       }
     },
-    "/log/list_details" : {
-      "get" : {
-        "tags" : [ "log" ],
-        "summary" : "get list of entities filetered by criteria in log_filter and return info specified by log_details_required with success or error code",
-        "parameters" : [ {
-          "name" : "requestor_id",
-          "in" : "query",
-          "required" : true,
-          "style" : "form",
-          "explode" : true,
-          "schema" : {
-            "type" : "string",
-            "example" : "healthngoadmin1"
+    "/log/list_details": {
+      "get": {
+        "tags": ["log"],
+        "summary": "get list of entities filetered by criteria in log_filter and return info specified by log_details_required with success or error code",
+        "parameters": [
+          {
+            "name": "requestor_id",
+            "in": "query",
+            "required": true,
+            "style": "form",
+            "explode": true,
+            "schema": {
+              "type": "string",
+              "example": "healthngoadmin1"
+            }
+          },
+          {
+            "name": "request_token",
+            "in": "query",
+            "required": true,
+            "style": "form",
+            "explode": true,
+            "schema": {
+              "type": "string",
+              "example": "Organizer"
+            }
+          },
+          {
+            "name": "qry",
+            "in": "query",
+            "required": true,
+            "style": "form",
+            "explode": true,
+            "schema": {
+              "$ref": "#/components/schemas/log_get_details_qry"
+            }
           }
-        }, {
-          "name" : "request_token",
-          "in" : "query",
-          "required" : true,
-          "style" : "form",
-          "explode" : true,
-          "schema" : {
-            "type" : "string",
-            "example" : "Organizer"
-          }
-        }, {
-          "name" : "qry",
-          "in" : "query",
-          "required" : true,
-          "style" : "form",
-          "explode" : true,
-          "schema" : {
-            "$ref" : "#/components/schemas/log_get_details_qry"
-          }
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "success,log list",
-            "content" : {
-              "json" : {
-                "schema" : {
-                  "type" : "array",
-                  "items" : {
-                    "$ref" : "#/components/schemas/log_list"
+        ],
+        "responses": {
+          "200": {
+            "description": "success,log list",
+            "content": {
+              "json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/log_list"
                   }
                 }
               }
             }
           },
-          "400" : {
-            "description" : "Invalid request"
+          "400": {
+            "description": "Invalid request"
           },
-          "403" : {
-            "description" : "No permission"
+          "403": {
+            "description": "No permission"
           },
-          "404" : {
-            "description" : "one or more specified inputs not found"
+          "404": {
+            "description": "one or more specified inputs not found"
           },
-          "default" : {
-            "description" : "Unexpected error"
+          "default": {
+            "description": "Unexpected error"
           }
         }
       }
     }
   },
-  "components" : {
-    "schemas" : {
-      "entity_list" : {
-        "type" : "array",
-        "items" : {
-          "type" : "object",
-          "properties" : {
-            "entity_id" : {
-              "type" : "string",
-              "example" : "67890"
+  "components": {
+    "schemas": {
+      "entity_list": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "entity_id": {
+              "type": "string",
+              "example": "67890"
             },
-            "details" : {
-              "$ref" : "#/components/schemas/entity_details"
+            "details": {
+              "$ref": "#/components/schemas/entity_details"
             }
           }
         }
       },
-      "entity_details" : {
-        "type" : "object",
-        "properties" : {
-          "category" : {
-            "type" : "string",
-            "example" : "hospital"
+      "entity_details": {
+        "type": "object",
+        "properties": {
+          "category": {
+            "type": "string",
+            "example": "hospital"
           },
-          "name" : {
-            "type" : "string",
-            "example" : "abc"
+          "name": {
+            "type": "string",
+            "example": "abc"
           },
-          "phone" : {
-            "type" : "string",
-            "example" : "+911234567890"
+          "phone": {
+            "type": "string",
+            "example": "+911234567890"
           },
-          "email" : {
-            "type" : "string",
-            "example" : "info@xyz.com"
+          "email": {
+            "type": "string",
+            "example": "info@xyz.com"
           },
-          "website" : {
-            "type" : "string",
-            "format" : "url",
-            "example" : "www.abc.com"
+          "website": {
+            "type": "string",
+            "format": "url",
+            "example": "www.abc.com"
           }
         }
       },
-      "entity_filter" : {
-        "type" : "object",
-        "properties" : {
-          "entity_id" : {
-            "type" : "array",
-            "items" : {
-              "type" : "string"
+      "entity_filter": {
+        "type": "object",
+        "properties": {
+          "entity_id": {
+            "type": "array",
+            "items": {
+              "type": "string"
             },
-            "example" : "[67890,12121]"
+            "example": "[67890,12121]"
           },
-          "category" : {
-            "type" : "string",
-            "example" : "hospital"
+          "category": {
+            "type": "string",
+            "example": "hospital"
           },
-          "name" : {
-            "type" : "string",
-            "example" : "abc"
+          "name": {
+            "type": "string",
+            "example": "abc"
           },
-          "phone" : {
-            "type" : "string",
-            "example" : "+911234567890"
+          "phone": {
+            "type": "string",
+            "example": "+911234567890"
           },
-          "email" : {
-            "type" : "string",
-            "example" : "info@xyz.com"
+          "email": {
+            "type": "string",
+            "example": "info@xyz.com"
           },
-          "website" : {
-            "type" : "string",
-            "format" : "url",
-            "example" : "www.abc.com"
+          "website": {
+            "type": "string",
+            "format": "url",
+            "example": "www.abc.com"
           }
         }
       },
-      "entity_details_required" : {
-        "type" : "object",
-        "properties" : {
-          "entity_id" : {
-            "type" : "boolean",
-            "example" : false
+      "entity_details_required": {
+        "type": "object",
+        "properties": {
+          "entity_id": {
+            "type": "boolean",
+            "example": false
           },
-          "category" : {
-            "type" : "boolean",
-            "example" : true
+          "category": {
+            "type": "boolean",
+            "example": true
           },
-          "name" : {
-            "type" : "boolean",
-            "example" : true
+          "name": {
+            "type": "boolean",
+            "example": true
           },
-          "phone" : {
-            "type" : "boolean",
-            "example" : true
+          "phone": {
+            "type": "boolean",
+            "example": true
           },
-          "email" : {
-            "type" : "boolean",
-            "example" : true
+          "email": {
+            "type": "boolean",
+            "example": true
           },
-          "website" : {
-            "type" : "boolean",
-            "example" : true
+          "website": {
+            "type": "boolean",
+            "example": true
           }
         }
       },
-      "appointment_creation_details" : {
-        "type" : "object",
-        "properties" : {
-          "exclusive" : {
-            "type" : "boolean",
-            "example" : "true"
+      "appointment_creation_details": {
+        "type": "object",
+        "properties": {
+          "exclusive": {
+            "type": "boolean",
+            "example": "true"
           },
-          "event_ids" : {
-            "type" : "array",
-            "items" : {
-              "type" : "string"
+          "event_ids": {
+            "type": "array",
+            "items": {
+              "type": "string"
             },
-            "example" : "[1]"
+            "example": "[1]"
           },
-          "participant_type" : {
-            "type" : "string",
-            "example" : "subscriber"
+          "participant_type": {
+            "type": "string",
+            "example": "subscriber"
           },
-          "participant_id" : {
-            "type" : "string",
-            "example" : "12345"
+          "participant_id": {
+            "type": "string",
+            "example": "12345"
           },
-          "participant_entity_id" : {
-            "type" : "string",
-            "example" : "67890"
+          "participant_entity_id": {
+            "type": "string",
+            "example": "67890"
           }
         }
       },
-      "appointment_list" : {
-        "type" : "array",
-        "items" : {
-          "type" : "object",
-          "properties" : {
-            "appointment_id" : {
-              "type" : "string",
-              "example" : "1"
+      "appointment_list": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "appointment_id": {
+              "type": "string",
+              "example": "1"
             },
-            "details" : {
-              "$ref" : "#/components/schemas/appointment_details"
+            "details": {
+              "$ref": "#/components/schemas/appointment_details"
             }
           }
         }
       },
-      "appointment_details" : {
-  "type" : "object",
-        "properties" : {
-          "exclusive" : {
-            "type" : "boolean",
-            "example" : "true"
+      "appointment_details": {
+        "type": "object",
+        "properties": {
+          "exclusive": {
+            "type": "boolean",
+            "example": "true"
           },
-          "event_id" : {
-            "type" : "string",
-            "example" : "1"
+          "event_id": {
+            "type": "string",
+            "example": "1"
           },
-          "participant_type" : {
-            "type" : "string",
-            "example" : "subscriber"
+          "participant_type": {
+            "type": "string",
+            "example": "subscriber"
           },
-          "participant_id" : {
-            "type" : "string",
-            "example" : "12345"
+          "participant_id": {
+            "type": "string",
+            "example": "12345"
           },
-          "status_id" : {
-            "type" : "string",
-            "example" : "confirmed"
+          "status_id": {
+            "type": "string",
+            "example": "confirmed"
           },
-          "participant_entity_id" : {
-            "type" : "string",
-            "example" : "67890"
+          "participant_entity_id": {
+            "type": "string",
+            "example": "67890"
           }
         }
       },
-      "appointment_filter" : {
-        "type" : "object",
-        "properties" : {
-          "exclusive" : {
-            "type" : "boolean",
-            "example" : "true"
+      "appointment_filter": {
+        "type": "object",
+        "properties": {
+          "exclusive": {
+            "type": "boolean",
+            "example": "true"
           },
-          "appointment_id" : {
-            "type" : "string",
-            "example" : "1"
+          "appointment_id": {
+            "type": "string",
+            "example": "1"
           },
-          "participant_type" : {
-            "type" : "string",
-            "example" : "subscriber"
+          "participant_type": {
+            "type": "string",
+            "example": "subscriber"
           },
-          "participant_id" : {
-            "type" : "string",
-            "example" : "12345"
+          "participant_id": {
+            "type": "string",
+            "example": "12345"
           },
-          "participant_entity_id" : {
-            "type" : "string",
-            "example" : "67890"
+          "participant_entity_id": {
+            "type": "string",
+            "example": "67890"
           },
-          "status" : {
-            "type" : "string",
-            "example" : "confirmed"
+          "status": {
+            "type": "string",
+            "example": "confirmed"
           },
-          "from" : {
-            "type" : "string",
-            "format" : "date-time",
-            "example" : "2018-02-15T09:00:00"
+          "from": {
+            "type": "string",
+            "format": "date-time",
+            "example": "2018-02-15T09:00:00"
           },
-          "to" : {
-            "type" : "string",
-            "format" : "date-time",
-            "example" : "2018-02-15T17:00:00"
+          "to": {
+            "type": "string",
+            "format": "date-time",
+            "example": "2018-02-15T17:00:00"
           }
         }
       },
-      "appointment_details_required" : {
-        "type" : "object",
-        "properties" : {
-          "exclusive" : {
-            "type" : "boolean",
-            "example" : "true"
+      "appointment_details_required": {
+        "type": "object",
+        "properties": {
+          "exclusive": {
+            "type": "boolean",
+            "example": "true"
           },
-          "appointment_id" : {
-            "type" : "boolean",
-            "example" : true
+          "appointment_id": {
+            "type": "boolean",
+            "example": true
           },
-          "event_details" : {
-            "type" : "boolean",
-            "example" : true
+          "event_details": {
+            "type": "boolean",
+            "example": true
           },
-          "participant_type" : {
-            "type" : "boolean",
-            "example" : true
+          "participant_type": {
+            "type": "boolean",
+            "example": true
           },
-          "participant_id" : {
-            "type" : "boolean",
-            "example" : true
+          "participant_id": {
+            "type": "boolean",
+            "example": true
           },
-          "status" : {
-            "type" : "boolean",
-            "example" : true
+          "status": {
+            "type": "boolean",
+            "example": true
           },
-          "participant_entity_id" : {
-            "type" : "boolean",
-            "example" : true
+          "participant_entity_id": {
+            "type": "boolean",
+            "example": true
           }
         }
       },
-      "resource_list" : {
-        "type" : "array",
-        "items" : {
-          "type" : "object",
-          "properties" : {
-            "resource_id" : {
-              "type" : "string",
-              "example" : "54321"
+      "resource_list": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "resource_id": {
+              "type": "string",
+              "example": "54321"
             },
-            "details" : {
-              "$ref" : "#/components/schemas/resource_details"
+            "details": {
+              "$ref": "#/components/schemas/resource_details"
             }
           }
         }
       },
-      "resource_details" : {
-        "type" : "object",
-        "properties" : {
-          "name" : {
-            "type" : "string",
-            "example" : "psrk"
+      "resource_details": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "example": "psrk"
           },
-          "category" : {
-            "type" : "string",
-            "example" : "doctor"
+          "category": {
+            "type": "string",
+            "example": "doctor"
           },
-          "phone" : {
-            "type" : "string",
-            "example" : "+911234567890"
+          "phone": {
+            "type": "string",
+            "example": "+911234567890"
           },
-          "email" : {
-            "type" : "string",
-            "example" : "doctor1@xyz.com"
+          "email": {
+            "type": "string",
+            "example": "doctor1@xyz.com"
           },
-          "alert_url" : {
-            "type" : "string",
-            "format" : "url",
-            "example" : "psrk@gmail.com"
+          "alert_url": {
+            "type": "string",
+            "format": "url",
+            "example": "psrk@gmail.com"
           },
-          "alert_preference" : {
-            "type" : "string",
-            "example" : "phone"
+          "alert_preference": {
+            "type": "string",
+            "example": "phone"
           },
-          "status_poll_url" : {
-            "type" : "string",
-            "format" : "url",
-            "example" : "www.doctor1.com"
+          "status_poll_url": {
+            "type": "string",
+            "format": "url",
+            "example": "www.doctor1.com"
           }
         }
       },
-      "resource_filter" : {
-        "type" : "object",
-        "properties" : {
-          "resource_id" : {
-            "type" : "array",
-            "items" : {
-              "type" : "string"
+      "resource_filter": {
+        "type": "object",
+        "properties": {
+          "resource_id": {
+            "type": "array",
+            "items": {
+              "type": "string"
             },
-            "example" : "[54321,31313]"
+            "example": "[54321,31313]"
           },
-          "name" : {
-            "type" : "string",
-            "example" : "psrk"
+          "name": {
+            "type": "string",
+            "example": "psrk"
           },
-          "category" : {
-            "type" : "string",
-            "example" : "doctor"
+          "category": {
+            "type": "string",
+            "example": "doctor"
           },
-          "phone" : {
-            "type" : "string",
-            "example" : "+911234567890"
+          "phone": {
+            "type": "string",
+            "example": "+911234567890"
           },
-          "email" : {
-            "type" : "string",
-            "example" : "abc@gmail.com"
+          "email": {
+            "type": "string",
+            "example": "abc@gmail.com"
           },
-          "alert_url" : {
-            "type" : "string",
-            "format" : "url",
-            "example" : "www.doctor1.com"
+          "alert_url": {
+            "type": "string",
+            "format": "url",
+            "example": "www.doctor1.com"
           },
-          "alert_preference" : {
-            "type" : "string",
-            "example" : " phone"
+          "alert_preference": {
+            "type": "string",
+            "example": " phone"
           },
-          "status_poll_url" : {
-            "type" : "string",
-            "format" : "url",
-            "example" : "www.doctor1.com"
+          "status_poll_url": {
+            "type": "string",
+            "format": "url",
+            "example": "www.doctor1.com"
           }
         }
       },
-      "resource_details_required" : {
-        "type" : "object",
-        "properties" : {
-          "resource_id" : {
-            "type" : "boolean",
-            "example" : true
+      "resource_details_required": {
+        "type": "object",
+        "properties": {
+          "resource_id": {
+            "type": "boolean",
+            "example": true
           },
-          "name" : {
-            "type" : "boolean",
-            "example" : true
+          "name": {
+            "type": "boolean",
+            "example": true
           },
-          "category" : {
-            "type" : "boolean",
-            "example" : true
+          "category": {
+            "type": "boolean",
+            "example": true
           },
-          "phone" : {
-            "type" : "boolean",
-            "example" : true
+          "phone": {
+            "type": "boolean",
+            "example": true
           },
-          "email" : {
-            "type" : "boolean",
-            "example" : true
+          "email": {
+            "type": "boolean",
+            "example": true
           },
-          "alert_url" : {
-            "type" : "boolean",
-            "example" : true
+          "alert_url": {
+            "type": "boolean",
+            "example": true
           },
-          "alert_preference" : {
-            "type" : "boolean",
-            "example" : true
+          "alert_preference": {
+            "type": "boolean",
+            "example": true
           },
-          "status_poll_url" : {
-            "type" : "boolean",
-            "example" : true
+          "status_poll_url": {
+            "type": "boolean",
+            "example": true
           }
         }
       },
-      "subscriber_list" : {
-        "type" : "array",
-        "items" : {
-          "type" : "object",
-          "properties" : {
-            "subscriber_id" : {
-              "type" : "string",
-              "example" : "12345"
+      "subscriber_list": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "subscriber_id": {
+              "type": "string",
+              "example": "12345"
             },
-            "details" : {
-              "$ref" : "#/components/schemas/subscriber_details"
+            "details": {
+              "$ref": "#/components/schemas/subscriber_details"
             }
           }
         }
       },
-      "subscriber_details" : {
-        "type" : "object",
-        "properties" : {
-          "name" : {
-            "type" : "string",
-            "example" : "abc"
+      "subscriber_details": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "example": "abc"
           },
-          "category" : {
-            "type" : "string",
-            "example" : "patient"
+          "category": {
+            "type": "string",
+            "example": "patient"
           },
-          "phone" : {
-            "type" : "string",
-            "example" : "+911234567890"
+          "phone": {
+            "type": "string",
+            "example": "+911234567890"
           },
-          "email" : {
-            "type" : "string",
-            "example" : "abc@gmail.com"
+          "email": {
+            "type": "string",
+            "example": "abc@gmail.com"
           },
-          "alert_url" : {
-            "type" : "string",
-            "format" : "url",
-            "example" : "www.abc.com"
+          "alert_url": {
+            "type": "string",
+            "format": "url",
+            "example": "www.abc.com"
           },
-          "alert_preference" : {
-            "type" : "string",
-            "example" : "phone"
+          "alert_preference": {
+            "type": "string",
+            "example": "phone"
           },
-          "status_poll_url" : {
-            "type" : "string",
-            "format" : "url",
-            "example" : "www.abc.com"
+          "status_poll_url": {
+            "type": "string",
+            "format": "url",
+            "example": "www.abc.com"
           }
         }
       },
-      "subscriber_filter" : {
-        "type" : "object",
-        "properties" : {
-          "subscriber_id" : {
-            "type" : "array",
-            "items" : {
-              "type" : "string"
+      "subscriber_filter": {
+        "type": "object",
+        "properties": {
+          "subscriber_id": {
+            "type": "array",
+            "items": {
+              "type": "string"
             },
-            "example" : "[12345, 41414]"
+            "example": "[12345, 41414]"
           },
-          "category" : {
-            "type" : "string",
-            "example" : "patient"
+          "category": {
+            "type": "string",
+            "example": "patient"
           },
-          "name" : {
-            "type" : "string",
-            "example" : "abc"
+          "name": {
+            "type": "string",
+            "example": "abc"
           },
-          "phone" : {
-            "type" : "string",
-            "example" : "+911234567890"
+          "phone": {
+            "type": "string",
+            "example": "+911234567890"
           },
-          "email" : {
-            "type" : "string",
-            "example" : "abc@gmail.com"
+          "email": {
+            "type": "string",
+            "example": "abc@gmail.com"
           },
-          "alert_url" : {
-            "type" : "string",
-            "format" : "url",
-            "example" : "www.abc.com"
+          "alert_url": {
+            "type": "string",
+            "format": "url",
+            "example": "www.abc.com"
           },
-          "alert_preference" : {
-            "type" : "string",
-            "example" : " phone"
+          "alert_preference": {
+            "type": "string",
+            "example": " phone"
           },
-          "status_poll_url" : {
-            "type" : "string",
-            "format" : "url",
-            "example" : "www.abc.com"
+          "status_poll_url": {
+            "type": "string",
+            "format": "url",
+            "example": "www.abc.com"
           }
         }
       },
-      "subscriber_details_required" : {
-        "type" : "object",
-        "properties" : {
-          "subscriber_id" : {
-            "type" : "boolean",
-            "example" : true
+      "subscriber_details_required": {
+        "type": "object",
+        "properties": {
+          "subscriber_id": {
+            "type": "boolean",
+            "example": true
           },
-          "category" : {
-            "type" : "boolean",
-            "example" : true
+          "category": {
+            "type": "boolean",
+            "example": true
           },
-          "name" : {
-            "type" : "boolean",
-            "example" : true
+          "name": {
+            "type": "boolean",
+            "example": true
           },
-          "phone" : {
-            "type" : "boolean",
-            "example" : true
+          "phone": {
+            "type": "boolean",
+            "example": true
           },
-          "email" : {
-            "type" : "boolean",
-            "example" : true
+          "email": {
+            "type": "boolean",
+            "example": true
           },
-          "alert_url" : {
-            "type" : "boolean",
-            "example" : true
+          "alert_url": {
+            "type": "boolean",
+            "example": true
           },
-          "alert_preference" : {
-            "type" : "boolean",
-            "example" : true
+          "alert_preference": {
+            "type": "boolean",
+            "example": true
           },
-          "status_poll_url" : {
-            "type" : "boolean",
-            "example" : true
+          "status_poll_url": {
+            "type": "boolean",
+            "example": true
           }
         }
       },
-      "event_creation_details" : {
-        "type" : "object",
-        "properties" : {
-          "name" : {
-            "type" : "string",
-            "example" : "abc medical camp"
+      "event_creation_details": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "example": "abc medical camp"
           },
-          "description" : {
-            "type" : "string",
-            "example" : "medical camp for senior citizens"
+          "description": {
+            "type": "string",
+            "example": "medical camp for senior citizens"
           },
-          "category" : {
-            "type" : "string",
-            "example" : "doctor_consultation"
+          "category": {
+            "type": "string",
+            "example": "doctor_consultation"
           },
-          "host_entity_id" : {
-            "type" : "string",
-            "example" : "67890"
+          "host_entity_id": {
+            "type": "string",
+            "example": "67890"
           },
-          "slots" : {
-            "type" : "array",
-            "items" : {
-              "type" : "object",
-              "properties" : {
-                "from" : {
-                  "type" : "string",
-                  "format" : "date-time",
-                  "example" : "2018-02-15T11:00:00"
+          "slots": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "from": {
+                  "type": "string",
+                  "format": "date-time",
+                  "example": "2018-02-15T11:00:00"
                 },
-                "to" : {
-                  "type" : "string",
-                  "format" : "date-time",
-                  "example" : "2018-02-15T11:30:00"
+                "to": {
+                  "type": "string",
+                  "format": "date-time",
+                  "example": "2018-02-15T11:30:00"
                 }
               }
             }
           },
-          "deadline" : {
-            "type" : "string",
-            "format" : "date-time",
-            "example" : "2018-02-15T11:10:00"
+          "deadline": {
+            "type": "string",
+            "format": "date-time",
+            "example": "2018-02-15T11:10:00"
           },
-          "subscriber_limit" : {
-            "type" : "string",
-            "example" : "1"
+          "subscriber_limit": {
+            "type": "string",
+            "example": "1"
           },
-          "terms" : {
-            "type" : "string",
-            "example" : "non refundable"
+          "terms": {
+            "type": "string",
+            "example": "non refundable"
           },
-          "status" : {
-            "type" : "string",
-            "example" : "open"
+          "status": {
+            "type": "string",
+            "example": "open"
           },
-          "venue" : {
-            "$ref" : "#/components/schemas/venue"
+          "venue": {
+            "$ref": "#/components/schemas/venue"
           }
         }
       },
-      "event_list" : {
-        "type" : "array",
-        "items" : {
-          "type" : "object",
-          "properties" : {
-            "event_id" : {
-              "type" : "string",
-              "example" : "12345"
+      "event_list": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "event_id": {
+              "type": "string",
+              "example": "12345"
             },
-            "details" : {
-              "$ref" : "#/components/schemas/event_details"
+            "details": {
+              "$ref": "#/components/schemas/event_details"
             }
           }
         }
       },
-      "event_details" : {
-        "type" : "object",
-        "properties" : {
-          "name" : {
-            "type" : "string",
-            "example" : "abc medical camp"
+      "event_details": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "example": "abc medical camp"
           },
-          "description" : {
-            "type" : "string",
-            "example" : "medical camp for senior citizens"
+          "description": {
+            "type": "string",
+            "example": "medical camp for senior citizens"
           },
-          "category" : {
-            "type" : "string",
-            "example" : "doctor_consultation"
+          "category": {
+            "type": "string",
+            "example": "doctor_consultation"
           },
-          "host_entity_id" : {
-            "type" : "string",
-            "example" : "67890"
+          "host_entity_id": {
+            "type": "string",
+            "example": "67890"
           },
-          "from" : {
-            "type" : "string",
-            "format" : "date-time",
-            "example" : "2018-02-15T11:00:00"
+          "from": {
+            "type": "string",
+            "format": "date-time",
+            "example": "2018-02-15T11:00:00"
           },
-          "to" : {
-            "type" : "string",
-            "format" : "date-time",
-            "example" : "2018-02-15T11:30:00"
+          "to": {
+            "type": "string",
+            "format": "date-time",
+            "example": "2018-02-15T11:30:00"
           },
-          "deadline" : {
-            "type" : "string",
-            "format" : "date-time",
-            "example" : "2018-02-15T11:10:00"
+          "deadline": {
+            "type": "string",
+            "format": "date-time",
+            "example": "2018-02-15T11:10:00"
           },
-          "subscriber_limit" : {
-            "type" : "string",
-            "example" : "1"
+          "subscriber_limit": {
+            "type": "string",
+            "example": "1"
           },
-          "terms" : {
-            "type" : "string",
-            "example" : "non refundable"
+          "terms": {
+            "type": "string",
+            "example": "non refundable"
           },
-          "status" : {
-            "type" : "string",
-            "example" : "open"
+          "status": {
+            "type": "string",
+            "example": "open"
           },
-          "venue" : {
-            "$ref" : "#/components/schemas/venue"
+          "venue": {
+            "$ref": "#/components/schemas/venue"
           }
         }
       },
-      "event_filter" : {
-        "type" : "object",
-        "properties" : {
-          "event_id" : {
-            "type" : "array",
-            "items" : {
-              "type" : "string"
+      "event_filter": {
+        "type": "object",
+        "properties": {
+          "event_id": {
+            "type": "array",
+            "items": {
+              "type": "string"
             },
-            "example" : "[12345,51515]"
+            "example": "[12345,51515]"
           },
-          "description" : {
-            "type" : "string",
-            "example" : "medical camp for senior citizens"
+          "description": {
+            "type": "string",
+            "example": "medical camp for senior citizens"
           },
-          "name" : {
-            "type" : "string",
-            "example" : "doctor_consultation"
+          "name": {
+            "type": "string",
+            "example": "doctor_consultation"
           },
-          "category" : {
-            "type" : "string",
-            "example" : "opd_physician_consultation"
+          "category": {
+            "type": "string",
+            "example": "opd_physician_consultation"
           },
-          "host_entity_id" : {
-            "type" : "string",
-            "example" : "67890"
+          "host_entity_id": {
+            "type": "string",
+            "example": "67890"
           },
-          "subscriber_limit" : {
-            "type" : "string",
-            "example" : "1"
+          "subscriber_limit": {
+            "type": "string",
+            "example": "1"
           },
-          "terms" : {
-            "type" : "string",
-            "example" : "non refundable"
+          "terms": {
+            "type": "string",
+            "example": "non refundable"
           },
-          "from" : {
-            "type" : "string",
-            "format" : "date-time",
-            "example" : "2018-02-15T09:00:00"
+          "from": {
+            "type": "string",
+            "format": "date-time",
+            "example": "2018-02-15T09:00:00"
           },
-          "to" : {
-            "type" : "string",
-            "format" : "date-time",
-            "example" : "2018-02-15T17:00:00"
+          "to": {
+            "type": "string",
+            "format": "date-time",
+            "example": "2018-02-15T17:00:00"
           },
-          "venue" : {
-            "$ref" : "#/components/schemas/venue"
+          "venue": {
+            "$ref": "#/components/schemas/venue"
           }
         }
       },
-      "event_details_required" : {
-        "type" : "object",
-        "properties" : {
-          "event_id" : {
-            "type" : "boolean",
-            "example" : true
+      "event_details_required": {
+        "type": "object",
+        "properties": {
+          "event_id": {
+            "type": "boolean",
+            "example": true
           },
-          "description" : {
-            "type" : "boolean",
-            "example" : true
+          "description": {
+            "type": "boolean",
+            "example": true
           },
-          "name" : {
-            "type" : "boolean",
-            "example" : true
+          "name": {
+            "type": "boolean",
+            "example": true
           },
-          "category" : {
-            "type" : "boolean",
-            "example" : true
+          "category": {
+            "type": "boolean",
+            "example": true
           },
-          "host_entity_id" : {
-            "type" : "boolean",
-            "example" : true
+          "host_entity_id": {
+            "type": "boolean",
+            "example": true
           },
-          "period" : {
-            "type" : "boolean",
-            "example" : true
+          "period": {
+            "type": "boolean",
+            "example": true
           },
-          "venue" : {
-            "type" : "boolean",
-            "example" : true
+          "venue": {
+            "type": "boolean",
+            "example": true
           },
-          "deadline" : {
-            "type" : "boolean",
-            "example" : true
+          "deadline": {
+            "type": "boolean",
+            "example": true
           },
-          "subscriber_limit" : {
-            "type" : "boolean",
-            "example" : true
+          "subscriber_limit": {
+            "type": "boolean",
+            "example": true
           },
-          "terms" : {
-            "type" : "boolean",
-            "example" : true
+          "terms": {
+            "type": "boolean",
+            "example": true
           },
-          "status" : {
-            "type" : "boolean",
-            "example" : true
+          "status": {
+            "type": "boolean",
+            "example": true
           }
         }
       },
-      "affiliation_list" : {
-        "type" : "array",
-        "items" : {
-          "type" : "object",
-          "properties" : {
-            "affiliation_id" : {
-              "type" : "string",
-              "example" : "1"
+      "affiliation_list": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "affiliation_id": {
+              "type": "string",
+              "example": "1"
             },
-            "details" : {
-              "$ref" : "#/components/schemas/affiliation_details"
+            "details": {
+              "$ref": "#/components/schemas/affiliation_details"
             }
           }
         }
       },
-      "affiliation_details" : {
-        "type" : "object",
-        "properties" : {
-          "resource_id" : {
-            "type" : "string",
-            "example" : "12345"
+      "affiliation_details": {
+        "type": "object",
+        "properties": {
+          "resource_id": {
+            "type": "string",
+            "example": "12345"
           },
-          "entity_id" : {
-            "type" : "string",
-            "example" : "67890"
+          "entity_id": {
+            "type": "string",
+            "example": "67890"
           },
-          "resource_category" : {
-            "type" : "string",
-            "example" : "physician"
+          "resource_category": {
+            "type": "string",
+            "example": "physician"
           },
-          "work_days_hours" : {
-            "$ref" : "#/components/schemas/days_hours"
+          "work_days_hours": {
+            "$ref": "#/components/schemas/days_hours"
           }
         }
       },
-      "days_hours" : {
-        "type" : "array",
-        "items" : {
-          "type" : "object",
-          "properties" : {
-            "day_of_week" : {
-              "type" : "string",
-              "example" : "[monday"
+      "days_hours": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "day_of_week": {
+              "type": "string",
+              "example": "[monday"
             },
-            "start_time" : {
-              "type" : "string",
-              "example" : "09:00:00"
+            "start_time": {
+              "type": "string",
+              "example": "09:00:00"
             },
-            "end_time" : {
-              "type" : "string",
-              "example" : "17:00:00"
+            "end_time": {
+              "type": "string",
+              "example": "17:00:00"
             }
           }
         }
       },
-      "affiliation_filter" : {
-        "type" : "object",
-        "properties" : {
-          "affiliation_id" : {
-            "type" : "array",
-            "items" : {
-              "type" : "string"
+      "affiliation_filter": {
+        "type": "object",
+        "properties": {
+          "affiliation_id": {
+            "type": "array",
+            "items": {
+              "type": "string"
             },
-            "example" : "[1,2]"
+            "example": "[1,2]"
           },
-          "resource_id" : {
-            "type" : "string",
-            "example" : "12345"
+          "resource_id": {
+            "type": "string",
+            "example": "12345"
           },
-          "entity_id" : {
-            "type" : "string",
-            "example" : "67890"
+          "entity_id": {
+            "type": "string",
+            "example": "67890"
           },
-          "category" : {
-            "type" : "string",
-            "example" : "physician"
+          "category": {
+            "type": "string",
+            "example": "physician"
           },
-          "from" : {
-            "type" : "string",
-            "format" : "date-time",
-            "example" : "2018-02-15T09:00:00"
+          "from": {
+            "type": "string",
+            "format": "date-time",
+            "example": "2018-02-15T09:00:00"
           },
-          "to" : {
-            "type" : "string",
-            "format" : "date-time",
-            "example" : "2018-02-15T17:00:00"
+          "to": {
+            "type": "string",
+            "format": "date-time",
+            "example": "2018-02-15T17:00:00"
           }
         }
       },
-      "affiliation_details_required" : {
-        "type" : "object",
-        "properties" : {
-          "affiliation_id" : {
-            "type" : "boolean",
-            "example" : true
+      "affiliation_details_required": {
+        "type": "object",
+        "properties": {
+          "affiliation_id": {
+            "type": "boolean",
+            "example": true
           },
-          "resource_id" : {
-            "type" : "boolean",
-            "example" : true
+          "resource_id": {
+            "type": "boolean",
+            "example": true
           },
-          "entity_id" : {
-            "type" : "boolean",
-            "example" : true
+          "entity_id": {
+            "type": "boolean",
+            "example": true
           },
-          "category" : {
-            "type" : "boolean",
-            "example" : true
+          "category": {
+            "type": "boolean",
+            "example": true
           },
-          "work_days_hours" : {
-            "type" : "boolean",
-            "example" : true
+          "work_days_hours": {
+            "type": "boolean",
+            "example": true
           }
         }
       },
-      "alert_schedule_list" : {
-        "type" : "array",
-        "items" : {
-          "type" : "object",
-          "properties" : {
-            "alert_schedule_id" : {
-              "type" : "string",
-              "example" : "1"
+      "alert_schedule_list": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "alert_schedule_id": {
+              "type": "string",
+              "example": "1"
             },
-            "details" : {
-              "$ref" : "#/components/schemas/alert_schedule_details"
+            "details": {
+              "$ref": "#/components/schemas/alert_schedule_details"
             }
           }
         }
       },
-      "alert_schedule_details" : {
-        "type" : "object",
-        "properties" : {
-          "event_id" : {
-            "type" : "string",
-            "example" : "12345"
+      "alert_schedule_details": {
+        "type": "object",
+        "properties": {
+          "event_id": {
+            "type": "string",
+            "example": "12345"
           },
-          "target_category" : {
-            "type" : "string",
-            "example" : "subscriber"
+          "target_category": {
+            "type": "string",
+            "example": "subscriber"
           },
-          "message_id" : {
-            "type" : "string",
-            "example" : "1"
+          "message_id": {
+            "type": "string",
+            "example": "1"
           },
-          "alert_datetime" : {
-            "type" : "string",
-            "format" : "date-time",
-            "example" : "2018-02-15T09:00:00"
+          "alert_datetime": {
+            "type": "string",
+            "format": "date-time",
+            "example": "2018-02-15T09:00:00"
           }
         }
       },
-      "alert_schedule_filter" : {
-        "type" : "object",
-        "properties" : {
-          "alert_schedule_id" : {
-            "type" : "array",
-            "items" : {
-              "type" : "string"
+      "alert_schedule_filter": {
+        "type": "object",
+        "properties": {
+          "alert_schedule_id": {
+            "type": "array",
+            "items": {
+              "type": "string"
             },
-            "example" : "[1,2]"
+            "example": "[1,2]"
           },
-          "entity_id" : {
-            "type" : "string",
-            "example" : "67890"
+          "entity_id": {
+            "type": "string",
+            "example": "67890"
           },
-          "target_category" : {
-            "type" : "string",
-            "example" : "subscriber"
+          "target_category": {
+            "type": "string",
+            "example": "subscriber"
           },
-          "message_id" : {
-            "type" : "string",
-            "example" : "1"
+          "message_id": {
+            "type": "string",
+            "example": "1"
           },
-          "from" : {
-            "type" : "string",
-            "format" : "date-time",
-            "example" : "2018-02-15T09:00:00"
+          "from": {
+            "type": "string",
+            "format": "date-time",
+            "example": "2018-02-15T09:00:00"
           },
-          "to" : {
-            "type" : "string",
-            "format" : "date-time",
-            "example" : "2018-02-15T13:30:00"
+          "to": {
+            "type": "string",
+            "format": "date-time",
+            "example": "2018-02-15T13:30:00"
           }
         }
       },
-      "alert_schedule_details_required" : {
-        "type" : "object",
-        "properties" : {
-          "alert_schedule_id" : {
-            "type" : "boolean",
-            "example" : true
+      "alert_schedule_details_required": {
+        "type": "object",
+        "properties": {
+          "alert_schedule_id": {
+            "type": "boolean",
+            "example": true
           },
-          "entity_id" : {
-            "type" : "boolean",
-            "example" : true
+          "entity_id": {
+            "type": "boolean",
+            "example": true
           },
-          "message_id" : {
-            "type" : "boolean",
-            "example" : true
+          "message_id": {
+            "type": "boolean",
+            "example": true
           },
-          "alert_datetime" : {
-            "type" : "boolean",
-            "example" : true
+          "alert_datetime": {
+            "type": "boolean",
+            "example": true
           }
         }
       },
-      "message_list" : {
-        "type" : "array",
-        "items" : {
-          "type" : "object",
-          "properties" : {
-            "message_id" : {
-              "type" : "string",
-              "example" : "1"
+      "message_list": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "message_id": {
+              "type": "string",
+              "example": "1"
             },
-            "details" : {
-              "$ref" : "#/components/schemas/message_details"
+            "details": {
+              "$ref": "#/components/schemas/message_details"
             }
           }
         }
       },
-      "message_details" : {
-        "type" : "object",
-        "properties" : {
-          "entity_id" : {
-            "type" : "string",
-            "example" : "67890"
+      "message_details": {
+        "type": "object",
+        "properties": {
+          "entity_id": {
+            "type": "string",
+            "example": "67890"
           },
-          "category" : {
-            "type" : "string",
-            "example" : "reminder"
+          "category": {
+            "type": "string",
+            "example": "reminder"
           },
-          "message_body" : {
-            "type" : "string",
-            "example" : "you have doctor consultation today"
+          "message_body": {
+            "type": "string",
+            "example": "you have doctor consultation today"
           }
         }
       },
-      "message_filter" : {
-        "type" : "object",
-        "properties" : {
-          "message_id" : {
-            "type" : "array",
-            "items" : {
-              "type" : "string"
+      "message_filter": {
+        "type": "object",
+        "properties": {
+          "message_id": {
+            "type": "array",
+            "items": {
+              "type": "string"
             },
-            "example" : "[1,2]"
+            "example": "[1,2]"
           },
-          "entity_id" : {
-            "type" : "string",
-            "example" : "67890"
+          "entity_id": {
+            "type": "string",
+            "example": "67890"
           },
-          "category" : {
-            "type" : "string",
-            "example" : "reminder"
+          "category": {
+            "type": "string",
+            "example": "reminder"
           },
-          "message_body" : {
-            "type" : "string",
-            "example" : "you have doctor consultation today"
+          "message_body": {
+            "type": "string",
+            "example": "you have doctor consultation today"
           }
         }
       },
-      "message_details_required" : {
-        "type" : "object",
-        "properties" : {
-          "message_id" : {
-            "type" : "boolean",
-            "example" : true
+      "message_details_required": {
+        "type": "object",
+        "properties": {
+          "message_id": {
+            "type": "boolean",
+            "example": true
           },
-          "entity_id" : {
-            "type" : "boolean",
-            "example" : true
+          "entity_id": {
+            "type": "boolean",
+            "example": true
           },
-          "category" : {
-            "type" : "boolean",
-            "example" : true
+          "category": {
+            "type": "boolean",
+            "example": true
           },
-          "message_body" : {
-            "type" : "boolean",
-            "example" : true
+          "message_body": {
+            "type": "boolean",
+            "example": true
           }
         }
       },
-      "log_list" : {
-        "type" : "array",
-        "items" : {
-          "type" : "object",
-          "properties" : {
-            "log_id" : {
-              "type" : "string",
-              "example" : "1"
+      "log_list": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "log_id": {
+              "type": "string",
+              "example": "1"
             },
-            "details" : {
-              "$ref" : "#/components/schemas/log_details"
+            "details": {
+              "$ref": "#/components/schemas/log_details"
             }
           }
         }
       },
-      "log_details" : {
-        "type" : "object",
-        "properties" : {
-          "logger_role" : {
-            "type" : "string",
-            "example" : "resource"
+      "log_details": {
+        "type": "object",
+        "properties": {
+          "logger_role": {
+            "type": "string",
+            "example": "resource"
           },
-          "logger_id" : {
-            "type" : "string",
-            "example" : "1"
+          "logger_id": {
+            "type": "string",
+            "example": "1"
           },
-          "entity_id" : {
-            "type" : "string",
-            "example" : "67890"
+          "entity_id": {
+            "type": "string",
+            "example": "67890"
           },
-          "log_category" : {
-            "type" : "string",
-            "example" : "attendance"
+          "log_category": {
+            "type": "string",
+            "example": "attendance"
           },
-          "datetime" : {
-            "type" : "string",
-            "format" : "date-time",
-            "example" : "2018-02-15T11:00:00"
+          "datetime": {
+            "type": "string",
+            "format": "date-time",
+            "example": "2018-02-15T11:00:00"
           },
-          "log_data" : {
-            "type" : "string",
-            "example" : "event_id:12345,subscriber_id:1,token:a2s3x2fer,status:attended"
+          "log_data": {
+            "type": "string",
+            "example": "event_id:12345,subscriber_id:1,token:a2s3x2fer,status:attended"
           }
         }
       },
-      "log_filter" : {
-        "type" : "object",
-        "properties" : {
-          "log_id" : {
-            "type" : "array",
-            "items" : {
-              "type" : "string"
+      "log_filter": {
+        "type": "object",
+        "properties": {
+          "log_id": {
+            "type": "array",
+            "items": {
+              "type": "string"
             },
-            "example" : "[1,2]"
+            "example": "[1,2]"
           },
-          "entity_id" : {
-            "type" : "string",
-            "example" : "67890"
+          "entity_id": {
+            "type": "string",
+            "example": "67890"
           },
-          "category" : {
-            "type" : "string",
-            "example" : "attendance"
+          "category": {
+            "type": "string",
+            "example": "attendance"
           },
-          "from" : {
-            "type" : "string",
-            "format" : "date-time",
-            "example" : "2018-02-15T11:00:00"
+          "from": {
+            "type": "string",
+            "format": "date-time",
+            "example": "2018-02-15T11:00:00"
           },
-          "to" : {
-            "type" : "string",
-            "format" : "date-time",
-            "example" : "2018-02-15T11:30:00"
+          "to": {
+            "type": "string",
+            "format": "date-time",
+            "example": "2018-02-15T11:30:00"
           }
         }
       },
-      "log_details_required" : {
-        "type" : "object",
-        "properties" : {
-          "log_id" : {
-            "type" : "boolean",
-            "example" : true
+      "log_details_required": {
+        "type": "object",
+        "properties": {
+          "log_id": {
+            "type": "boolean",
+            "example": true
           },
-          "logger_category" : {
-            "type" : "boolean",
-            "example" : true
+          "logger_category": {
+            "type": "boolean",
+            "example": true
           },
-          "logger_id" : {
-            "type" : "boolean",
-            "example" : true
+          "logger_id": {
+            "type": "boolean",
+            "example": true
           },
-          "entity_id" : {
-            "type" : "boolean",
-            "example" : true
+          "entity_id": {
+            "type": "boolean",
+            "example": true
           },
-          "log_category" : {
-            "type" : "boolean",
-            "example" : true
+          "log_category": {
+            "type": "boolean",
+            "example": true
           },
-          "datetime" : {
-            "type" : "boolean",
-            "example" : true
+          "datetime": {
+            "type": "boolean",
+            "example": true
           },
-          "log_data" : {
-            "type" : "boolean",
-            "example" : true
+          "log_data": {
+            "type": "boolean",
+            "example": true
           }
         }
       },
-      "free_resource_list" : {
-        "type" : "array",
-        "items" : {
-          "$ref" : "#/components/schemas/free_resource_details"
+      "free_resource_list": {
+        "type": "array",
+        "items": {
+          "$ref": "#/components/schemas/free_resource_details"
         }
       },
-      "free_resource_details" : {
-        "type" : "object",
-        "properties" : {
-          "resource_id" : {
-            "type" : "string",
-            "example" : "1"
+      "free_resource_details": {
+        "type": "object",
+        "properties": {
+          "resource_id": {
+            "type": "string",
+            "example": "1"
           },
-          "resource_name" : {
-            "type" : "string",
-            "example" : "abc"
+          "resource_name": {
+            "type": "string",
+            "example": "abc"
           },
-          "free_slots" : {
-            "type" : "array",
-            "items" : {
-              "type" : "string",
-              "example" : "{[2018-02-15T11:00:00to2018-02-15T11:09:00:00],[2018-02-22T11:00:00to2018-02-22T11:17:00:00]}"
+          "free_slots": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "example": "{[2018-02-15T11:00:00to2018-02-15T11:09:00:00],[2018-02-22T11:00:00to2018-02-22T11:17:00:00]}"
             }
           }
         }
       },
-      "free_resource_filter" : {
-        "type" : "object",
-        "properties" : {
-          "category" : {
-            "type" : "string",
-            "example" : "doctor"
+      "free_resource_filter": {
+        "type": "object",
+        "properties": {
+          "category": {
+            "type": "string",
+            "example": "doctor"
           },
-          "Entity_id" : {
-            "type" : "string",
-            "example" : "67890"
+          "Entity_id": {
+            "type": "string",
+            "example": "67890"
           },
-          "from" : {
-            "type" : "string",
-            "format" : "date-time",
-            "example" : "2018-02-14T09:00:00"
+          "from": {
+            "type": "string",
+            "format": "date-time",
+            "example": "2018-02-14T09:00:00"
           },
-          "to" : {
-            "type" : "string",
-            "format" : "date-time",
-            "example" : "2018-02-18T13:30:00"
+          "to": {
+            "type": "string",
+            "format": "date-time",
+            "example": "2018-02-18T13:30:00"
           },
-          "resource_id" : {
-            "type" : "string",
-            "example" : "1"
+          "resource_id": {
+            "type": "string",
+            "example": "1"
           }
         }
       },
-      "venue" : {
-        "type" : "object",
-        "properties" : {
-          "building" : {
-            "type" : "string",
-            "example" : "xyz"
+      "venue": {
+        "type": "object",
+        "properties": {
+          "building": {
+            "type": "string",
+            "example": "xyz"
           },
-          "street" : {
-            "type" : "string",
-            "example" : "7th main"
+          "street": {
+            "type": "string",
+            "example": "7th main"
           },
-          "area" : {
-            "type" : "string",
-            "example" : "wilson garden"
+          "area": {
+            "type": "string",
+            "example": "wilson garden"
           },
-          "city" : {
-            "type" : "string",
-            "example" : "bangalore"
+          "city": {
+            "type": "string",
+            "example": "bangalore"
           },
-          "state" : {
-            "type" : "string",
-            "example" : "karnataka"
+          "state": {
+            "type": "string",
+            "example": "karnataka"
           },
-          "country" : {
-            "type" : "string",
-            "example" : "india"
+          "country": {
+            "type": "string",
+            "example": "india"
           },
-          "lat" : {
-            "type" : "string",
-            "example" : "0.001"
+          "lat": {
+            "type": "string",
+            "example": "0.001"
           },
-          "long" : {
-            "type" : "string",
-            "example" : "0.002"
+          "long": {
+            "type": "string",
+            "example": "0.002"
           }
         }
       },
-      "event_new_qry" : {
-        "type" : "object",
-        "properties" : {
-          "details" : {
-            "$ref" : "#/components/schemas/event_creation_details"
+      "event_new_qry": {
+        "type": "object",
+        "properties": {
+          "details": {
+            "$ref": "#/components/schemas/event_creation_details"
           }
         }
       },
-      "event_modify_qry" : {
-        "type" : "object",
-        "properties" : {
-          "details" : {
-            "$ref" : "#/components/schemas/event_details"
+      "event_modify_qry": {
+        "type": "object",
+        "properties": {
+          "details": {
+            "$ref": "#/components/schemas/event_details"
           }
         }
       },
-      "event_get_details_qry" : {
-        "type" : "object",
-        "properties" : {
-          "event_filter" : {
-            "$ref" : "#/components/schemas/event_filter"
+      "event_get_details_qry": {
+        "type": "object",
+        "properties": {
+          "event_filter": {
+            "$ref": "#/components/schemas/event_filter"
           },
-          "event_details_required" : {
-            "$ref" : "#/components/schemas/event_details_required"
+          "event_details_required": {
+            "$ref": "#/components/schemas/event_details_required"
           }
         }
       },
-      "entity_new_qry" : {
-        "type" : "object",
-        "properties" : {
-          "details" : {
-            "$ref" : "#/components/schemas/entity_details"
+      "entity_new_qry": {
+        "type": "object",
+        "properties": {
+          "details": {
+            "$ref": "#/components/schemas/entity_details"
           }
         }
       },
-      "entity_modify_qry" : {
-        "type" : "object",
-        "properties" : {
-          "details" : {
-            "$ref" : "#/components/schemas/entity_details"
+      "entity_modify_qry": {
+        "type": "object",
+        "properties": {
+          "details": {
+            "$ref": "#/components/schemas/entity_details"
           }
         }
       },
-      "entity_get_details_qry" : {
-        "type" : "object",
-        "properties" : {
-          "entity_filter" : {
-            "$ref" : "#/components/schemas/entity_filter"
+      "entity_get_details_qry": {
+        "type": "object",
+        "properties": {
+          "entity_filter": {
+            "$ref": "#/components/schemas/entity_filter"
           },
-          "entity_details_required" : {
-            "$ref" : "#/components/schemas/entity_details_required"
+          "entity_details_required": {
+            "$ref": "#/components/schemas/entity_details_required"
           }
         }
       },
-      "resource_new_qry" : {
-        "type" : "object",
-        "properties" : {
-          "resource_details" : {
-            "$ref" : "#/components/schemas/resource_details"
+      "resource_new_qry": {
+        "type": "object",
+        "properties": {
+          "resource_details": {
+            "$ref": "#/components/schemas/resource_details"
           }
         }
       },
-      "resource_modify_qry" : {
-        "type" : "object",
-        "properties" : {
-          "details" : {
-            "$ref" : "#/components/schemas/resource_details"
+      "resource_modify_qry": {
+        "type": "object",
+        "properties": {
+          "details": {
+            "$ref": "#/components/schemas/resource_details"
           }
         }
       },
-      "resource_get_details_qry" : {
-        "type" : "object",
-        "properties" : {
-          "resource_filter" : {
-            "$ref" : "#/components/schemas/resource_filter"
+      "resource_get_details_qry": {
+        "type": "object",
+        "properties": {
+          "resource_filter": {
+            "$ref": "#/components/schemas/resource_filter"
           },
-          "resource_details_required" : {
-            "$ref" : "#/components/schemas/resource_details_required"
+          "resource_details_required": {
+            "$ref": "#/components/schemas/resource_details_required"
           }
         }
       },
-      "resource_get_availability_qry" : {
-        "type" : "object",
-        "properties" : {
-          "free_resource_filter" : {
-            "$ref" : "#/components/schemas/free_resource_filter"
+      "resource_get_availability_qry": {
+        "type": "object",
+        "properties": {
+          "free_resource_filter": {
+            "$ref": "#/components/schemas/free_resource_filter"
           }
         }
       },
-      "subscriber_new_qry" : {
-        "type" : "object",
-        "properties" : {
-          "subscriber_details" : {
-            "$ref" : "#/components/schemas/subscriber_details"
+      "subscriber_new_qry": {
+        "type": "object",
+        "properties": {
+          "subscriber_details": {
+            "$ref": "#/components/schemas/subscriber_details"
           }
         }
       },
-      "subscriber_modify_qry" : {
-        "type" : "object",
-        "properties" : {
-          "details" : {
-            "$ref" : "#/components/schemas/subscriber_details"
+      "subscriber_modify_qry": {
+        "type": "object",
+        "properties": {
+          "details": {
+            "$ref": "#/components/schemas/subscriber_details"
           }
         }
       },
-      "subscriber_get_details_qry" : {
-        "type" : "object",
-        "properties" : {
-          "subscriber_filter" : {
-            "$ref" : "#/components/schemas/subscriber_filter"
+      "subscriber_get_details_qry": {
+        "type": "object",
+        "properties": {
+          "subscriber_filter": {
+            "$ref": "#/components/schemas/subscriber_filter"
           },
-          "subscriber_details_required" : {
-            "$ref" : "#/components/schemas/subscriber_details_required"
+          "subscriber_details_required": {
+            "$ref": "#/components/schemas/subscriber_details_required"
           }
         }
       },
-      "message_new_qry" : {
-        "type" : "object",
-        "properties" : {
-          "message_details" : {
-            "$ref" : "#/components/schemas/message_details"
+      "message_new_qry": {
+        "type": "object",
+        "properties": {
+          "message_details": {
+            "$ref": "#/components/schemas/message_details"
           }
         }
       },
-      "message_modify_qry" : {
-        "type" : "object",
-        "properties" : {
-          "details" : {
-            "$ref" : "#/components/schemas/message_details"
+      "message_modify_qry": {
+        "type": "object",
+        "properties": {
+          "details": {
+            "$ref": "#/components/schemas/message_details"
           }
         }
       },
-      "message_get_details_qry" : {
-        "type" : "object",
-        "properties" : {
-          "message_filter" : {
-            "$ref" : "#/components/schemas/message_filter"
+      "message_get_details_qry": {
+        "type": "object",
+        "properties": {
+          "message_filter": {
+            "$ref": "#/components/schemas/message_filter"
           },
-          "message_details_required" : {
-            "$ref" : "#/components/schemas/message_details_required"
+          "message_details_required": {
+            "$ref": "#/components/schemas/message_details_required"
           }
         }
       },
-      "affiliation_new_qry" : {
-        "type" : "object",
-        "properties" : {
-          "affiliation_details" : {
-            "$ref" : "#/components/schemas/affiliation_details"
+      "affiliation_new_qry": {
+        "type": "object",
+        "properties": {
+          "affiliation_details": {
+            "$ref": "#/components/schemas/affiliation_details"
           }
         }
       },
-      "affiliation_modify_qry" : {
-        "type" : "object",
-        "properties" : {
-          "details" : {
-            "$ref" : "#/components/schemas/affiliation_details"
+      "affiliation_modify_qry": {
+        "type": "object",
+        "properties": {
+          "details": {
+            "$ref": "#/components/schemas/affiliation_details"
           }
         }
       },
-      "affiliation_get_details_qry" : {
-        "type" : "object",
-        "properties" : {
-          "affiliation_filter" : {
-            "$ref" : "#/components/schemas/affiliation_filter"
+      "affiliation_get_details_qry": {
+        "type": "object",
+        "properties": {
+          "affiliation_filter": {
+            "$ref": "#/components/schemas/affiliation_filter"
           },
-          "affiliation_details_required" : {
-            "$ref" : "#/components/schemas/affiliation_details_required"
+          "affiliation_details_required": {
+            "$ref": "#/components/schemas/affiliation_details_required"
           }
         }
       },
-      "alert_schedule_new_qry" : {
-        "type" : "object",
-        "properties" : {
-          "alert_schedule_details" : {
-            "$ref" : "#/components/schemas/alert_schedule_details"
+      "alert_schedule_new_qry": {
+        "type": "object",
+        "properties": {
+          "alert_schedule_details": {
+            "$ref": "#/components/schemas/alert_schedule_details"
           }
         }
       },
-      "alert_schedule_modify_qry" : {
-        "type" : "object",
-        "properties" : {
-          "details" : {
-            "$ref" : "#/components/schemas/alert_schedule_details"
+      "alert_schedule_modify_qry": {
+        "type": "object",
+        "properties": {
+          "details": {
+            "$ref": "#/components/schemas/alert_schedule_details"
           }
         }
       },
-      "alert_schedule_get_details_qry" : {
-        "type" : "object",
-        "properties" : {
-          "alert_schedule_filter" : {
-            "$ref" : "#/components/schemas/alert_schedule_filter"
+      "alert_schedule_get_details_qry": {
+        "type": "object",
+        "properties": {
+          "alert_schedule_filter": {
+            "$ref": "#/components/schemas/alert_schedule_filter"
           },
-          "alert_schedule_details_required" : {
-            "$ref" : "#/components/schemas/alert_schedule_details_required"
+          "alert_schedule_details_required": {
+            "$ref": "#/components/schemas/alert_schedule_details_required"
           }
         }
       },
-      "log_new_qry" : {
-        "type" : "object",
-        "properties" : {
-          "log_details" : {
-            "$ref" : "#/components/schemas/log_details"
+      "log_new_qry": {
+        "type": "object",
+        "properties": {
+          "log_details": {
+            "$ref": "#/components/schemas/log_details"
           }
         }
       },
-      "log_modify_qry" : {
-        "type" : "object",
-        "properties" : {
-          "details" : {
-            "$ref" : "#/components/schemas/log_details"
+      "log_modify_qry": {
+        "type": "object",
+        "properties": {
+          "details": {
+            "$ref": "#/components/schemas/log_details"
           }
         }
       },
-      "log_get_details_qry" : {
-        "type" : "object",
-        "properties" : {
-          "log_filter" : {
-            "$ref" : "#/components/schemas/log_filter"
+      "log_get_details_qry": {
+        "type": "object",
+        "properties": {
+          "log_filter": {
+            "$ref": "#/components/schemas/log_filter"
           },
-          "log_details_required" : {
-            "$ref" : "#/components/schemas/log_details_required"
+          "log_details_required": {
+            "$ref": "#/components/schemas/log_details_required"
           }
         }
       },
-      "appointment_new_qry" : {
-        "type" : "object",
-        "properties" : {
-          "appointment_details" : {
-            "$ref" : "#/components/schemas/appointment_creation_details"
+      "appointment_new_qry": {
+        "type": "object",
+        "properties": {
+          "appointment_details": {
+            "$ref": "#/components/schemas/appointment_creation_details"
           }
         }
       },
-      "appointment_modify_qry" : {
-        "type" : "object",
-        "properties" : {
-          "details" : {
-            "$ref" : "#/components/schemas/appointment_details"
+      "appointment_modify_qry": {
+        "type": "object",
+        "properties": {
+          "details": {
+            "$ref": "#/components/schemas/appointment_details"
           }
         }
       },
-      "appointment_get_details_qry" : {
-        "type" : "object",
-        "properties" : {
-          "appointment_filter" : {
-            "$ref" : "#/components/schemas/appointment_filter"
+      "appointment_get_details_qry": {
+        "type": "object",
+        "properties": {
+          "appointment_filter": {
+            "$ref": "#/components/schemas/appointment_filter"
           },
-          "appointment_details_required" : {
-            "$ref" : "#/components/schemas/appointment_details_required"
+          "appointment_details_required": {
+            "$ref": "#/components/schemas/appointment_details_required"
           }
         }
       }


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above. Prefix with the associated issue number. -->

## Description
Removed the trailing slash from the `servers.url` field in the OpenAPI specification.  
Previously, the base URL ended with `/creg/`, and the paths started with a `/`, which resulted in double slashes (`//`) in the generated URLs.  
This change ensures that the final URLs are properly formed without redundant slashes.

## Related Issue
N/A – This is a cleanup task to improve URL formatting consistency in the documentation.

## Motivation and Context
The OpenAPI documentation currently builds URLs like:
`http://ss2.egovstack.net/.../creg//event/new`
This is due to a trailing slash in the `servers.url` and a leading slash in each path.  
While it doesn’t always break functionality, it's not a clean or standard-compliant format.  
This update improves clarity, avoids potential routing issues, and enhances the overall documentation quality.

## How Has This Been Tested?
- Validated in [Swagger Editor](https://editor.swagger.io) — no errors or warnings.
- Checked in Swagger UI — all endpoints load correctly.
- Confirmed that URLs are now generated without double slashes.
- Reviewed rendered paths to ensure consistency.
